### PR TITLE
chore(core): upgrade lettuce-core 6.1.5.RELEASE -> 7.7.0.RELEASE

### DIFF
--- a/akka-bbb-apps/project/Dependencies.scala
+++ b/akka-bbb-apps/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     val jackson = "2.22.1"
     // jackson-annotations drops the patch component from 2.20 on: the 2.22.1 suite pins it at 2.22.
     val jacksonAnnotations = "2.22"
-    val netty = "4.1.137.Final"
+    val netty = "4.2.17.Final"
     val logback = "1.5.38"
     val slf4j = "2.0.17"
     val quicklens = "1.7.5"

--- a/akka-bbb-fsesl/project/Dependencies.scala
+++ b/akka-bbb-fsesl/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
     val pekkoHttpVersion = "1.0.0"
     val logback = "1.5.38"
     val jackson = "2.18.9"
-    val netty = "4.1.137.Final"
+    val netty = "4.2.17.Final"
     val slf4j = "2.0.17"
 
     // Apache Commons

--- a/bbb-common-message/project/Dependencies.scala
+++ b/bbb-common-message/project/Dependencies.scala
@@ -22,12 +22,16 @@ object Dependencies {
     val jacksonDataFormat = "2.22.1"
 
     // Redis
-    val lettuce = "6.1.5.RELEASE"
+    val lettuce = "7.7.0.RELEASE"
 
-    // Netty. Explicitly pinned to lift the netty 4.1.68.Final that
-    // lettuce-core 6.1.5.RELEASE pulls in. These pins can be
-    // dropped once lettuce-core is upgraded to a release carrying newer netty.
-    val netty = "4.1.137.Final"
+    // Netty. Explicitly pinned to lift the netty 4.2.x that lettuce-core
+    // pulls in to the current patched release. Lettuce's bundled netty lags
+    // the security tip, so retarget this pin on future lettuce upgrades
+    // rather than dropping it.
+    val netty = "4.2.17.Final"
+
+    // reactor-core: lettuce transitive; only the 3.8 line receives fixes.
+    val reactor = "3.8.7"
 
     // Test
     val scalaTest = "3.0.8"
@@ -51,6 +55,9 @@ object Dependencies {
     // and win conflict resolution over lettuce-core's older transitive netty.
     val nettyHandler = "io.netty" % "netty-handler" % Versions.netty
     val nettyCodec = "io.netty" % "netty-codec" % Versions.netty
+    val nettyCodecDns = "io.netty" % "netty-codec-dns" % Versions.netty
+    val nettyResolverDns = "io.netty" % "netty-resolver-dns" % Versions.netty
+    val reactorCore = "io.projectreactor" % "reactor-core" % Versions.reactor
     val jacksonDataFormat = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jacksonDataFormat
   }
 
@@ -79,5 +86,8 @@ object Dependencies {
     Compile.lettuceCore,
     Compile.nettyHandler,
     Compile.nettyCodec,
+    Compile.nettyCodecDns,
+    Compile.nettyResolverDns,
+    Compile.reactorCore,
     Compile.jacksonDataFormat) ++ testing
 }

--- a/bbb-common-message/src/main/java/org/bigbluebutton/common2/redis/RedisStorageService.java
+++ b/bbb-common-message/src/main/java/org/bigbluebutton/common2/redis/RedisStorageService.java
@@ -44,7 +44,7 @@ public class RedisStorageService extends RedisAwareCommunicator {
     public void start() {
         log.info("Starting RedisStorageService with client name: clientName={}", clientName);
         RedisURI redisUri = RedisURI.Builder.redis(this.host, this.port).withClientName(this.clientName)
-                .withPassword(this.password).build();
+                .withPassword(this.password.toCharArray()).build();
 
         redisClient = RedisClient.create(redisUri);
         redisClient.setOptions(ClientOptions.builder().autoReconnect(true).build());

--- a/bbb-common-message/src/main/java/org/bigbluebutton/common2/redis/RedisStorageService.java
+++ b/bbb-common-message/src/main/java/org/bigbluebutton/common2/redis/RedisStorageService.java
@@ -43,8 +43,12 @@ public class RedisStorageService extends RedisAwareCommunicator {
 
     public void start() {
         log.info("Starting RedisStorageService with client name: clientName={}", clientName);
-        RedisURI redisUri = RedisURI.Builder.redis(this.host, this.port).withClientName(this.clientName)
-                .withPassword(this.password.toCharArray()).build();
+        RedisURI.Builder redisUriBuilder = RedisURI.Builder.redis(this.host, this.port)
+                .withClientName(this.clientName);
+        if (!this.password.isEmpty()) {
+            redisUriBuilder.withPassword(this.password.toCharArray());
+        }
+        RedisURI redisUri = redisUriBuilder.build();
 
         redisClient = RedisClient.create(redisUri);
         redisClient.setOptions(ClientOptions.builder().autoReconnect(true).build());

--- a/bbb-common-message/src/main/java/org/bigbluebutton/common2/redis/pubsub/MessageReceiver.java
+++ b/bbb-common-message/src/main/java/org/bigbluebutton/common2/redis/pubsub/MessageReceiver.java
@@ -34,10 +34,11 @@ public class MessageReceiver extends RedisAwareCommunicator {
         log.info("Ready to receive messages from Redis pubsub.");
         receiveMessage = true;
 
-        RedisURI redisUri = RedisURI.Builder.redis(this.host, this.port).withClientName(this.clientName).build();
+        RedisURI.Builder redisUriBuilder = RedisURI.Builder.redis(this.host, this.port).withClientName(this.clientName);
         if (!this.password.isEmpty()) {
-            redisUri.setPassword(this.password);
+            redisUriBuilder.withPassword(this.password.toCharArray());
         }
+        RedisURI redisUri = redisUriBuilder.build();
 
         redisClient = RedisClient.create(redisUri);
         redisClient.setOptions(ClientOptions.builder().autoReconnect(true).build());

--- a/bbb-common-message/src/main/java/org/bigbluebutton/common2/redis/pubsub/MessageSender.java
+++ b/bbb-common-message/src/main/java/org/bigbluebutton/common2/redis/pubsub/MessageSender.java
@@ -36,10 +36,11 @@ public class MessageSender extends RedisAwareCommunicator {
     }
 
     public void start() {
-        RedisURI redisUri = RedisURI.Builder.redis(this.host, this.port).withClientName(this.clientName).build();
+        RedisURI.Builder redisUriBuilder = RedisURI.Builder.redis(this.host, this.port).withClientName(this.clientName);
         if (!this.password.isEmpty()) {
-            redisUri.setPassword(this.password);
+            redisUriBuilder.withPassword(this.password.toCharArray());
         }
+        RedisURI redisUri = redisUriBuilder.build();
 
         redisClient = RedisClient.create(redisUri);
         redisClient.setOptions(ClientOptions.builder().autoReconnect(true).build());

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/redis/RedisClientProvider.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/redis/RedisClientProvider.scala
@@ -17,7 +17,9 @@ abstract class RedisClientProvider(
     case None       => ""
   }
 
-  val redisUri = RedisURI.Builder.redis(redisConfig.host, redisConfig.port).withClientName(clientName).withPassword(redisPassword.toCharArray()).build()
+  val redisUriBuilder = RedisURI.Builder.redis(redisConfig.host, redisConfig.port).withClientName(clientName)
+  if (redisPassword.nonEmpty) redisUriBuilder.withPassword(redisPassword.toCharArray())
+  val redisUri = redisUriBuilder.build()
 
   var redis = RedisClient.create(redisUri)
   redis.setOptions(ClientOptions.builder().autoReconnect(true).build())

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/redis/RedisClientProvider.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/redis/RedisClientProvider.scala
@@ -17,7 +17,7 @@ abstract class RedisClientProvider(
     case None       => ""
   }
 
-  val redisUri = RedisURI.Builder.redis(redisConfig.host, redisConfig.port).withClientName(clientName).withPassword(redisPassword).build()
+  val redisUri = RedisURI.Builder.redis(redisConfig.host, redisConfig.port).withClientName(clientName).withPassword(redisPassword.toCharArray()).build()
 
   var redis = RedisClient.create(redisUri)
   redis.setOptions(ClientOptions.builder().autoReconnect(true).build())

--- a/bigbluebutton-web/build.gradle
+++ b/bigbluebutton-web/build.gradle
@@ -28,7 +28,8 @@ version "0.10.0"
 group "org.bigbluebutton.web"
 
 ext['tomcat.version'] = '10.1.56'
-ext['netty.version'] = '4.1.137.Final'
+ext['netty.version'] = '4.2.17.Final'
+ext['lettuce.version'] = '7.7.0.RELEASE'
 ext['postgresql.version'] = '42.7.13'
 ext['spring-framework.version'] = '6.2.19'
 ext['jackson-bom.version'] = '2.22.1'
@@ -118,7 +119,7 @@ dependencies {
   implementation "org.bigbluebutton:bbb-common-web:0.0.5-SNAPSHOT"
 
   implementation "io.lettuce:lettuce-core"
-  implementation "io.projectreactor:reactor-core:3.6.0"
+  implementation "io.projectreactor:reactor-core:3.8.7"
   implementation "org.reactivestreams:reactive-streams:1.0.4"
 
   implementation "org.freemarker:freemarker:2.3.34"


### PR DESCRIPTION
### What does this PR do?
Upgrades lettuce-core (the Redis client used by bbb-web, akka-apps and
fsesl-akka for all inter-component messaging) from 6.1.5.RELEASE (Nov 2021)
to 7.7.0.RELEASE, and moves the Redis transport to the netty 4.2 line

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes # none

### Motivation
<!-- What inspired you to submit this pull request? -->
Upgrade `netty` to a more recent, maintained version (currently a 2021 version requiring explicit pins when bumping dependencies)

