### PR TITLE
[3.0 WB] fix viewer's unfaithful slide position by panning

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/component.jsx
@@ -467,7 +467,7 @@ class Presentation extends PureComponent {
 
   zoomChanger(zoom) {
     const { currentSlide } = this.props;
-    let boundZoom = parseInt(zoom, 10);
+    let boundZoom = Math.round(zoom);
     const min = currentSlide?.infiniteWhiteboard ? MIN_PERCENT : HUNDRED_PERCENT;
     if (boundZoom < min) {
       boundZoom = min;

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1463,8 +1463,9 @@ const Whiteboard = React.memo((props) => {
               editor?.getViewportPageBounds()?.h,
               currentPresentationPageRef.current?.scaledHeight,
             );
-            const tlCamPercent = Math.round(
-              (nextCam.z / (initialZoomRef.current || 1)) * 100
+            const tlCamPercent = parseInt(
+              (nextCam.z / (initialZoomRef.current || 1)) * 100,
+              10,
             );
 
             if (tlCamPercent !== zoomValueRef.current) {

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -1463,9 +1463,8 @@ const Whiteboard = React.memo((props) => {
               editor?.getViewportPageBounds()?.h,
               currentPresentationPageRef.current?.scaledHeight,
             );
-            const tlCamPercent = parseInt(
-              (nextCam.z / (initialZoomRef.current || 1)) * 100,
-              10,
+            const tlCamPercent = Math.round(
+              (nextCam.z / (initialZoomRef.current || 1)) * 100
             );
 
             if (tlCamPercent !== zoomValueRef.current) {


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
<s>This PR changes the calculation of tlCamPercent from Math.round() to parseInt() so that it uses the same integer conversion as BBB's zoomValue.</s>
This PR changes the calculation of boundZoom in zoomChanger() at whiteboard from parseInt() to Math.round() so that it uses the same integer conversion as tldraw's zoom-level value.
This prevents valid pan updates from being rejected when the tldraw camera zoom contains a fractional value.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #25690 (fixes only the pan problem, but not the cursor position delay)

### Motivation
<!-- What inspired you to submit this pull request? -->
BBB stores the presentation zoom percentage using `parseInt()`, while `tlCamPercent`, which is derived from the tldraw camera, was calculated using `Math.round().` (see https://github.com/bigbluebutton/bigbluebutton/blob/f42351ebb2ea19f3ff472eb4de085aebc6c346ad/bigbluebutton-html5/imports/ui/components/presentation/component.jsx#L470 for the parseInt part)
Because of this difference, the two values could differ by 1 even though they represented the same zoom level. For example in my investigation:
```
tldraw zoom: 215.73%
BBB zoom:    215%

Math.round(215.73) = 216
parseInt(215.73)   = 215
```
actually happened.

The camera synchronization check requires these values to match before publishing pan updates. When they differed, valid pan updates were skipped, causing the presenter's and viewers' camera positions to become desynchronized. Changing the zoom level would usually synchronize them again.
Using the same integer conversion on both sides keeps the existing synchronization logic while avoiding this false mismatch.

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->

1. Join a meeting with one presenter and one viewer.
2. Zoom the presentation to various (hopefully non-integer) zoom levels.
3. Pan the presentation repeatedly in different directions and at different speeds.
4. Confirm that the viewer continues to show the same presentation area as the presenter.

### More
<!-- Anything else we should know when reviewing? -->
- [ ] Added/updated documentation
