### PR TITLE
[3.0 WB] fix: add trailing to throttling for cursor updates

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -312,7 +312,7 @@ const WhiteboardContainer = (props) => {
 
   useEffect(() => () => {
     throttledPublishCursorUpdate.cancel();
-  }, [throttledPublishCursorUpdate]);
+  }, [throttledPublishCursorUpdate, curPageId]);
 
   const isMultiUserActive = whiteboardWriters.filter((u) => !u.presenter)?.length > 0;
   const cursorArray = useMergedCursorData();

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -312,7 +312,7 @@ const WhiteboardContainer = (props) => {
 
   useEffect(() => () => {
     throttledPublishCursorUpdate.cancel();
-  }, [throttledPublishCursorUpdate, curPageId]);
+  }, [throttledPublishCursorUpdate]);
 
   const isMultiUserActive = whiteboardWriters.filter((u) => !u.presenter)?.length > 0;
   const cursorArray = useMergedCursorData();

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -307,12 +307,12 @@ const WhiteboardContainer = (props) => {
       publishCursorUpdate,
       WHITEBOARD_CONFIG.cursorInterval,
     ),
-    [publishCursorUpdate, WHITEBOARD_CONFIG.cursorInterval],
+    [publishCursorUpdate, WHITEBOARD_CONFIG.cursorInterval, curPageId],
   );
 
   useEffect(() => () => {
     throttledPublishCursorUpdate.cancel();
-  }, [throttledPublishCursorUpdate, curPageId]);
+  }, [throttledPublishCursorUpdate]);
 
   const isMultiUserActive = whiteboardWriters.filter((u) => !u.presenter)?.length > 0;
   const cursorArray = useMergedCursorData();

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/container.jsx
@@ -54,6 +54,65 @@ import connectionStatus from '/imports/ui/core/graphql/singletons/connectionStat
 const RECONNECT_SYNC_DELAY_MS = 750;
 const VISIBILITY_REFETCH_DELAY_MS = 500;
 
+const throttleWithTrailing = (func, interval) => {
+  let pendingArgs = null;
+  let trailingTimer = null;
+  let lastInvokeTime = 0;
+
+  const throttled = throttle(
+    { interval },
+    (...args) => {
+      lastInvokeTime = performance.now();
+      func(...args);
+    },
+  );
+
+  const scheduleTrailing = () => {
+    if (trailingTimer) return;
+
+    const elapsed = performance.now() - lastInvokeTime;
+    const delay = Math.max(interval - elapsed, 1);
+
+    trailingTimer = setTimeout(() => {
+      trailingTimer = null;
+      if (!pendingArgs) return;
+
+      // Radash's internal timer may not have fired yet.
+      if (throttled.isThrottled()) {
+        scheduleTrailing();
+        return;
+      }
+      const args = pendingArgs;
+      pendingArgs = null;
+      throttled(...args);
+    }, delay);
+  };
+
+  const throttledWithTrailing = (...args) => {
+    if (!throttled.isThrottled()) {
+      pendingArgs = null;
+      if (trailingTimer) {
+        clearTimeout(trailingTimer);
+        trailingTimer = null;
+      }
+      throttled(...args);
+      return;
+    }
+    // Always keep only the latest cursor position.
+    pendingArgs = args;
+    scheduleTrailing();
+  };
+
+  throttledWithTrailing.cancel = () => {
+    pendingArgs = null;
+    if (trailingTimer) {
+      clearTimeout(trailingTimer);
+      trailingTimer = null;
+    }
+  };
+  return throttledWithTrailing;
+};
+
 const WhiteboardContainer = (props) => {
   const {
     zoomChanger,
@@ -243,12 +302,17 @@ const WhiteboardContainer = (props) => {
     });
   }, [hasWBAccess, isPresenter]);
 
-  const throttledPublishCursorUpdate = useMemo(() => {
-    return throttle(
-    { interval: WHITEBOARD_CONFIG.cursorInterval },
-    publishCursorUpdate,
+  const throttledPublishCursorUpdate = useMemo(() =>
+    throttleWithTrailing(
+      publishCursorUpdate,
+      WHITEBOARD_CONFIG.cursorInterval,
+    ),
+    [publishCursorUpdate, WHITEBOARD_CONFIG.cursorInterval],
   );
-  }, [publishCursorUpdate]);
+
+  useEffect(() => () => {
+    throttledPublishCursorUpdate.cancel();
+  }, [throttledPublishCursorUpdate, curPageId]);
 
   const isMultiUserActive = whiteboardWriters.filter((u) => !u.presenter)?.length > 0;
   const cursorArray = useMergedCursorData();


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
This PR adds trailing execution to the throttled cursor updates while continuing to use Radash's existing throttle, which only performs leading execution. This new wrapper keeps the latest cursor position received during the throttle interval and publishes it when the interval ends. The pending trailing update is also cancelled when the throttled publisher is cleaned up, preventing stale cursor updates from being published after an important whiteboard context changes.

### Closes Issue(s)
<!-- List here all the issues closed by this pull request. Use keyword `closes` before each issue number
Closes #123456
-->
Closes #25690 , together with the PR #25691 .

### Motivation
<!-- What inspired you to submit this pull request? -->
When a presenter moves the cursor quickly, the viewer's cursor can occasionally stop slightly behind the presenter's actual cursor position (see #25690).
The problem occurs because Radash's throttle is leading-only. For example, if a cursor update is published at the beginning of a throttle interval, subsequent positions during that interval are discarded. If the presenter stops moving the cursor before another interval begins, no further pointer event occurs and the final cursor position is never published. This can result in the presenter and viewers permanently displaying slightly different cursor positions until the presenter moves the cursor again.
Importantly, this behavior appears (to me) different from the cursor throttling used in previous BigBlueButton versions:

- BBB 2.6 used Lodash's throttle, whose default behavior includes both leading and trailing execution.
- In BBB 2.7, cursor updates were moved to BBB's native throttle implementation, while replacing Lodash with Radash throughout the whole code  (#16797). In this version, the trailing execution was still enabled.
- In BBB 3.0, cursor publishing was changed to Radash's throttle, which is actually leading-only, so the previous trailing behavior was lost.

This PR tries to restore the trailing behavior for cursor publishing without reintroducing Lodash or replacing Radash (by Radashi, for example).

### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
Start a meeting, move the cursor relatively quickly as a presenter, and check if the viewer's cursor follows the update.

### More
<!-- Anything else we should know when reviewing? -->
The trailing wrapper also exposes a cancel() method so that a pending trailing cursor update can be discarded when the throttled publisher itself is disposed or replaced, similar to the earlier versions of BBB.
<s> This cleanup is so far only tied to the lifetime of the throttled publisher. The AI that helped me to write the code suggested to include the page change for triggering the cancel method, but I am not sure if it makes sense. </s> -> I put back curPageId based on the suggestion by codeRabbit.
