### PR TITLE
[3.0]chore(core): Grails 7.0.12 backport from BBB 4.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ stages:
 
 # define which docker image to use for builds
 default:
-  image: bigbluebutton/bbb-build:v3.0.x-release--2026-08-06-162230
+  image: bigbluebutton/bbb-build:v3.0.x-release--2026-08-27-183101
 
 # This stage uses git to find out since when each package has been unmodified.
 # it then checks an API endpoint on the package server to find out for which of

--- a/akka-bbb-apps/project/Dependencies.scala
+++ b/akka-bbb-apps/project/Dependencies.scala
@@ -15,7 +15,9 @@ object Dependencies {
     val pekkoVersion = "1.0.1"
     val pekkoHttpVersion = "1.0.0"
     val gson = "2.8.9"
-    val jackson = "2.18.9"
+    val jackson = "2.22.1"
+    // jackson-annotations drops the patch component from 2.20 on: the 2.22.1 suite pins it at 2.22.
+    val jacksonAnnotations = "2.22"
     val netty = "4.1.137.Final"
     val logback = "1.5.38"
     val slf4j = "2.0.17"
@@ -41,7 +43,7 @@ object Dependencies {
     val scalaTest = "3.2.11"
     val mockito = "2.23.0"
     val akkaTestKit = "2.6.0"
-    val jacksonDataFormat = "2.18.9"
+    val jacksonDataFormat = "2.22.1"
   }
 
   object Compile {
@@ -125,7 +127,7 @@ object Dependencies {
   val overrides = Seq(
     "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson,
     "com.fasterxml.jackson.core" % "jackson-core" % Versions.jackson,
-    "com.fasterxml.jackson.core" % "jackson-annotations" % Versions.jackson,
+    "com.fasterxml.jackson.core" % "jackson-annotations" % Versions.jacksonAnnotations,
     "io.netty" % "netty-handler" % Versions.netty,
     "io.netty" % "netty-codec" % Versions.netty,
     "io.netty" % "netty-common" % Versions.netty,

--- a/akka-bbb-fsesl/project/Dependencies.scala
+++ b/akka-bbb-fsesl/project/Dependencies.scala
@@ -15,7 +15,9 @@ object Dependencies {
     val pekkoVersion = "1.0.1"
     val pekkoHttpVersion = "1.0.0"
     val logback = "1.5.38"
-    val jackson = "2.18.9"
+    val jackson = "2.22.1"
+    // jackson-annotations drops the patch component from 2.20 on: the 2.22.1 suite pins it at 2.22.
+    val jacksonAnnotations = "2.22"
     val netty = "4.1.137.Final"
     val slf4j = "2.0.17"
 
@@ -92,7 +94,7 @@ object Dependencies {
   val overrides = Seq(
     "com.fasterxml.jackson.core" % "jackson-databind" % Versions.jackson,
     "com.fasterxml.jackson.core" % "jackson-core" % Versions.jackson,
-    "com.fasterxml.jackson.core" % "jackson-annotations" % Versions.jackson,
+    "com.fasterxml.jackson.core" % "jackson-annotations" % Versions.jacksonAnnotations,
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % Versions.jackson,
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % Versions.jackson,
     "io.netty" % "netty-handler" % Versions.netty,

--- a/bbb-common-message/project/Dependencies.scala
+++ b/bbb-common-message/project/Dependencies.scala
@@ -15,11 +15,11 @@ object Dependencies {
     // Libraries
     val pekkoVersion = "1.0.1"
     val gson = "2.8.9"
-    val jackson = "2.18.9"
+    val jackson = "2.22.1"
     val sl4j = "1.7.32"
     val pool = "2.11.1"
     val codec = "1.15"
-    val jacksonDataFormat = "2.18.9"
+    val jacksonDataFormat = "2.22.1"
 
     // Redis
     val lettuce = "6.1.5.RELEASE"

--- a/bbb-common-web/project/Dependencies.scala
+++ b/bbb-common-web/project/Dependencies.scala
@@ -54,6 +54,9 @@ object Dependencies {
     val googleGson = "com.google.code.gson" % "gson" % Versions.gson
     val jacksonModule = "com.fasterxml.jackson.module" %% "jackson-module-scala" % Versions.jackson
     val jacksonXml = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-xml" % Versions.jackson
+    // Direct dep so it wins conflict resolution over the jackson-dataformat-cbor 2.17.2
+    // that aws-java-sdk-core pulls in, keeping the whole jackson suite on one version.
+    val jacksonCbor = "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % Versions.jackson
     val freemarker = "org.freemarker" % "freemarker" % Versions.freemarker
     val awsSdkS3 = "com.amazonaws" % "aws-java-sdk-s3" % Versions.awsSdkS3
     val apacheHttp = "org.apache.httpcomponents" % "httpclient" % Versions.apacheHttp
@@ -95,6 +98,7 @@ object Dependencies {
     Compile.googleGson,
     Compile.jacksonModule,
     Compile.jacksonXml,
+    Compile.jacksonCbor,
     Compile.freemarker,
     Compile.awsSdkS3,
     Compile.apacheHttp,

--- a/bigbluebutton-web/gradle.properties
+++ b/bigbluebutton-web/gradle.properties
@@ -1,4 +1,4 @@
-grailsVersion=7.0.8
+grailsVersion=7.0.12
 gradleWrapperVersion=8.14.3
 groovyVersion=4.0.21
 springVersion=3.5.16


### PR DESCRIPTION
Backports #25613 to BBB 3.0 (the grails and jackson portion. The rest was ported in https://github.com/bigbluebutton/bigbluebutton/pull/25679)