### PR TITLE
[3.0]build: Bump Go and NodeJS version in image used for packages building

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ stages:
 
 # define which docker image to use for builds
 default:
-  image: bigbluebutton/bbb-build:v3.0.x-release--2026-08-27-183101
+  image: bigbluebutton/bbb-build:v3.0.x-release--2026-08-27-215028
 
 # This stage uses git to find out since when each package has been unmodified.
 # it then checks an API endpoint on the package server to find out for which of


### PR DESCRIPTION
Backport of #25698 