### PR TITLE
feat: Add support for custom text in the recording permission dialog

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/db/MeetingDAO.scala
@@ -14,6 +14,11 @@ case class MeetingSystemColumnsDbModel(
       bannerColor:                           Option[String],
 )
 
+case class MeetingRecordingNotificationColumnsDbModel(
+    notifyRecordingIsOn:   Boolean,
+    notifyRecordingAppend: String,
+)
+
 case class MeetingDbModel(
     meetingId:                             String,
     extId:                                 String,
@@ -25,7 +30,7 @@ case class MeetingDbModel(
     cameraBridge:                          String,
     screenShareBridge:                     String,
     audioBridge:                           String,
-    notifyRecordingIsOn:                   Boolean,
+    recordingNotificationColumns:          MeetingRecordingNotificationColumnsDbModel,
     presentationUploadExternalDescription: String,
     presentationUploadExternalUrl:         String,
     learningDashboardAccessToken:          String,
@@ -51,7 +56,7 @@ class MeetingDbTableDef(tag: Tag) extends Table[MeetingDbModel](tag, None, "meet
     cameraBridge,
     screenShareBridge,
     audioBridge,
-    notifyRecordingIsOn,
+    recordingNotificationColumns,
     presentationUploadExternalDescription,
     presentationUploadExternalUrl,
     learningDashboardAccessToken,
@@ -75,6 +80,8 @@ class MeetingDbTableDef(tag: Tag) extends Table[MeetingDbModel](tag, None, "meet
   val screenShareBridge = column[String]("screenShareBridge")
   val audioBridge = column[String]("audioBridge")
   val notifyRecordingIsOn = column[Boolean]("notifyRecordingIsOn")
+  val notifyRecordingAppend = column[String]("notifyRecordingAppend")
+  val recordingNotificationColumns = (notifyRecordingIsOn, notifyRecordingAppend) <> (MeetingRecordingNotificationColumnsDbModel.tupled, MeetingRecordingNotificationColumnsDbModel.unapply)
   val presentationUploadExternalDescription = column[String]("presentationUploadExternalDescription")
   val presentationUploadExternalUrl = column[String]("presentationUploadExternalUrl")
   val learningDashboardAccessToken = column[String]("learningDashboardAccessToken")
@@ -109,7 +116,10 @@ object MeetingDAO {
           cameraBridge = meetingProps.meetingProp.cameraBridge,
           screenShareBridge = meetingProps.meetingProp.screenShareBridge,
           audioBridge = meetingProps.meetingProp.audioBridge,
-          notifyRecordingIsOn = meetingProps.meetingProp.notifyRecordingIsOn,
+          recordingNotificationColumns = MeetingRecordingNotificationColumnsDbModel(
+            notifyRecordingIsOn = meetingProps.meetingProp.notifyRecordingIsOn,
+            notifyRecordingAppend = meetingProps.meetingProp.notifyRecordingAppend,
+          ),
           presentationUploadExternalDescription = meetingProps.meetingProp.presentationUploadExternalDescription,
           presentationUploadExternalUrl = meetingProps.meetingProp.presentationUploadExternalUrl,
           learningDashboardAccessToken = meetingProps.password.learningDashboardAccessToken,

--- a/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
+++ b/bbb-common-message/src/main/scala/org/bigbluebutton/common2/domain/Meeting2x.scala
@@ -23,6 +23,7 @@ case class MeetingProp(
     isBreakout:                             Boolean,
     disabledFeatures:                       Vector[String],
     notifyRecordingIsOn:                    Boolean,
+    notifyRecordingAppend:                  String,
     presentationUploadExternalDescription:  String,
     presentationUploadExternalUrl:          String,
 )

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ApiParams.java
@@ -84,6 +84,7 @@ public class ApiParams {
     public static final String CLIENT_SETTINGS_OVERRIDE_JSON_URL = "clientSettingsOverrideJsonUrl";
     public static final String DISABLED_FEATURES_EXCLUDE = "disabledFeaturesExclude";
     public static final String NOTIFY_RECORDING_IS_ON = "notifyRecordingIsOn";
+    public static final String NOTIFY_RECORDING_APPEND = "notifyRecordingAppend";
 
     public static final String PRESENTATION_UPLOAD_EXTERNAL_DESCRIPTION = "presentationUploadExternalDescription";
     public static final String PRESENTATION_UPLOAD_EXTERNAL_URL = "presentationUploadExternalUrl";

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/MeetingService.java
@@ -695,7 +695,7 @@ public class MeetingService implements MessageListener {
             m.getMuteOnStart(), m.getAllowModsToUnmuteUsers(), m.getAllowModsToEjectCameras(), m.getMeetingKeepEvents(),
             m.breakoutRoomsParams, m.lockSettingsParams, m.getLoginUrl(), m.getLogoutUrl(), m.getCustomLogoURL(), m.getCustomDarkLogoURL(),
             m.getBannerText(), m.getBannerColor(), m.getGroups(), m.getDisabledFeatures(), m.getNotifyRecordingIsOn(),
-            m.getPresentationUploadExternalDescription(), m.getPresentationUploadExternalUrl(), m.getPlugins(),
+            m.getNotifyRecordingAppend(), m.getPresentationUploadExternalDescription(), m.getPresentationUploadExternalUrl(), m.getPlugins(),
             m.getHtml5PluginSdkVersion(), m.getOverrideClientSettings());
   }
 
@@ -940,6 +940,7 @@ public class MeetingService implements MessageListener {
       params.put(ApiParams.CAMERA_BRIDGE, message.cameraBridge);
       params.put(ApiParams.SCREEN_SHARE_BRIDGE, message.screenShareBridge);
       params.put(ApiParams.NOTIFY_RECORDING_IS_ON,parentMeeting.getNotifyRecordingIsOn().toString());
+      params.put(ApiParams.NOTIFY_RECORDING_APPEND, parentMeeting.getNotifyRecordingAppend());
       params.put(ApiParams.DISABLED_FEATURES,String.join(",", message.disabledFeatures));
       params.put(ApiParams.GUEST_POLICY, GuestPolicy.ALWAYS_ACCEPT);
 

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/ParamsProcessorUtil.java
@@ -811,6 +811,11 @@ public class ParamsProcessorUtil {
             notifyRecordingIsOn = Boolean.parseBoolean(params.get(ApiParams.NOTIFY_RECORDING_IS_ON));
         }
 
+        String notifyRecordingAppend = "";
+        if (!StringUtils.isBlank(params.get(ApiParams.NOTIFY_RECORDING_APPEND))) {
+            notifyRecordingAppend = ParamsUtil.stripControlChars(params.get(ApiParams.NOTIFY_RECORDING_APPEND));
+        }
+
         boolean multiUserWhiteboardEnabled = false;
         if (isBreakout) {
             multiUserWhiteboardEnabled = defaultBreakoutRoomsMultiUserWhiteboardDefaultOn;
@@ -1037,6 +1042,7 @@ public class ParamsProcessorUtil {
                 .withHtml5PluginSdkVersion(html5PluginSdkVersion)
                 .withDisabledFeatures(listOfDisabledFeatures)
                 .withNotifyRecordingIsOn(notifyRecordingIsOn)
+                .withNotifyRecordingAppend(notifyRecordingAppend)
                 .withPresentationUploadExternalDescription(presentationUploadExternalDescription)
                 .withPresentationUploadExternalUrl(presentationUploadExternalUrl)
                 .build();

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api/domain/Meeting.java
@@ -57,6 +57,7 @@ public class Meeting {
 	private String learningDashboardAccessToken;
 	private ArrayList<String> disabledFeatures;
 	private Boolean notifyRecordingIsOn;
+	private String notifyRecordingAppend = "";
 	private String welcomeMsgTemplate;
 	private String welcomeMsg;
 	private String welcomeMsgForModerators = "";
@@ -151,6 +152,7 @@ public class Meeting {
 		pluginManifests = builder.pluginManifests;
 		html5PluginSdkVersion = builder.html5PluginSdkVersion;
 		notifyRecordingIsOn = builder.notifyRecordingIsOn;
+		notifyRecordingAppend = builder.notifyRecordingAppend;
 		presentationUploadExternalDescription = builder.presentationUploadExternalDescription;
 		presentationUploadExternalUrl = builder.presentationUploadExternalUrl;
 		if (builder.viewerPass == null){
@@ -495,6 +497,10 @@ public class Meeting {
 
 	public Boolean getNotifyRecordingIsOn() {
 		return notifyRecordingIsOn;
+	}
+
+	public String getNotifyRecordingAppend() {
+		return notifyRecordingAppend;
 	}
 
 	public String getPresentationUploadExternalDescription() {
@@ -1068,6 +1074,7 @@ public class Meeting {
 		private ArrayList<PluginManifest> pluginManifests;
 		private String html5PluginSdkVersion;
 		private Boolean notifyRecordingIsOn;
+		private String notifyRecordingAppend = "";
 		private String presentationUploadExternalDescription;
 		private String presentationUploadExternalUrl;
     	private int duration;
@@ -1265,6 +1272,11 @@ public class Meeting {
 	    	this.notifyRecordingIsOn = b;
 	    	return this;
 	    }
+
+		public Builder withNotifyRecordingAppend(String message) {
+			this.notifyRecordingAppend = message;
+			return this;
+		}
 
     	public Builder withPresentationUploadExternalDescription(String d) {
 	    	this.presentationUploadExternalDescription = d;

--- a/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
+++ b/bbb-common-web/src/main/java/org/bigbluebutton/api2/IBbbWebApiGWApp.java
@@ -74,6 +74,7 @@ public interface IBbbWebApiGWApp {
                      ArrayList<Group> groups,
                      ArrayList<String> disabledFeatures,
                      Boolean notifyRecordingIsOn,
+                     String notifyRecordingAppend,
                      String presentationUploadExternalDescription,
                      String presentationUploadExternalUrl,
                      Map<String, Object> plugins,

--- a/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
+++ b/bbb-common-web/src/main/scala/org/bigbluebutton/api2/BbbWebApiGWApp.scala
@@ -174,6 +174,7 @@ class BbbWebApiGWApp(
                     groups:                                 java.util.ArrayList[Group],
                     disabledFeatures:                       java.util.ArrayList[String],
                     notifyRecordingIsOn:                    java.lang.Boolean,
+                    notifyRecordingAppend:                  String,
                     presentationUploadExternalDescription:  String,
                     presentationUploadExternalUrl:          String,
                     plugins:                                util.Map[String, AnyRef],
@@ -198,6 +199,7 @@ class BbbWebApiGWApp(
       isBreakout = isBreakout.booleanValue(),
       disabledFeaturesAsVector,
       notifyRecordingIsOn,
+      notifyRecordingAppend,
       presentationUploadExternalDescription,
       presentationUploadExternalUrl
     )

--- a/bbb-graphql-client-test/src/MeetingInfo.js
+++ b/bbb-graphql-client-test/src/MeetingInfo.js
@@ -13,6 +13,7 @@ export default function MeetingInfo() {
         maxPinnedCameras
         meetingCameraCap
         name
+        notifyRecordingAppend
         notifyRecordingIsOn
         presentationUploadExternalDescription
         presentationUploadExternalUrl

--- a/bbb-graphql-server/bbb-graphql-schema.md
+++ b/bbb-graphql-server/bbb-graphql-schema.md
@@ -27,6 +27,7 @@
 - `meetingCameraCap`
 - `meetingId`
 - `name`
+- `notifyRecordingAppend`
 - `notifyRecordingIsOn`
 - `presentationUploadExternalDescription`
 - `presentationUploadExternalUrl`

--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -30,6 +30,7 @@ create unlogged table "meeting" (
 	"screenShareBridge" varchar(30),
 	"audioBridge" varchar(30),
 	"notifyRecordingIsOn" boolean,
+	"notifyRecordingAppend" text,
 	"presentationUploadExternalDescription" text,
 	"presentationUploadExternalUrl" text,
 	"learningDashboardAccessToken" varchar(100),

--- a/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
+++ b/bbb-graphql-server/metadata/databases/BigBlueButton/tables/public_v_meeting.yaml
@@ -182,6 +182,7 @@ select_permissions:
         - audioBridge
         - meetingId
         - name
+        - notifyRecordingAppend
         - notifyRecordingIsOn
         - presentationUploadExternalDescription
         - presentationUploadExternalUrl
@@ -216,6 +217,7 @@ select_permissions:
         - meetingCameraCap
         - meetingId
         - name
+        - notifyRecordingAppend
         - notifyRecordingIsOn
         - presentationUploadExternalDescription
         - presentationUploadExternalUrl

--- a/bbb-graphql-server/metadata/query_collections.yaml
+++ b/bbb-graphql-server/metadata/query_collections.yaml
@@ -40,6 +40,7 @@
               customLogoUrl
               customDarkLogoUrl
               notifyRecordingIsOn
+              notifyRecordingAppend
               presentationUploadExternalDescription
               presentationUploadExternalUrl
               recordingPolicies {

--- a/bigbluebutton-html5/imports/ui/Types/meeting.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meeting.ts
@@ -132,6 +132,7 @@ export interface Meeting {
   meetingId: string;
   name: string;
   notifyRecordingIsOn: boolean;
+  notifyRecordingAppend: string;
   presentationUploadExternalDescription: string;
   presentationUploadExternalUrl: string;
   usersPolicies: UsersPolicies;

--- a/bigbluebutton-html5/imports/ui/Types/meetingStaticData.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingStaticData.ts
@@ -19,6 +19,7 @@ export interface MeetingStaticData {
   customLogoUrl: string | null;
   customDarkLogoUrl: string | null;
   notifyRecordingIsOn: boolean;
+  notifyRecordingAppend: string;
   presentationUploadExternalDescription: string;
   presentationUploadExternalUrl: string;
   recordingPolicies: {

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/component.tsx
@@ -88,6 +88,7 @@ interface RecordingIndicatorProps {
   micUser: boolean;
   isPhone: boolean;
   recordingNotificationEnabled: boolean;
+  notifyRecordingAppend: string;
   serverTime: number;
   isModerator: boolean;
   hasError: boolean;
@@ -103,6 +104,7 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
   isModerator,
   record,
   recordingNotificationEnabled,
+  notifyRecordingAppend,
   hasError,
   isLoading,
 }) => {
@@ -314,6 +316,7 @@ const RecordingIndicator: React.FC<RecordingIndicatorProps> = ({
           }}
           priority="high"
           isOpen={isRecordingNotifyModalOpen}
+          notifyRecordingAppend={notifyRecordingAppend}
           closeModal={() => {
             setIsRecordingNotifyModalOpen(false);
             setShouldNotify(false);
@@ -360,6 +363,7 @@ const RecordingIndicatorContainer: React.FC = () => {
   } = useMeeting((meeting) => ({
     meetingId: meeting.meetingId,
     notifyRecordingIsOn: meeting.notifyRecordingIsOn,
+    notifyRecordingAppend: meeting.notifyRecordingAppend,
     recordingPolicies: meeting.recordingPolicies,
   }));
 
@@ -419,6 +423,7 @@ const RecordingIndicatorContainer: React.FC = () => {
           && currentMeeting?.notifyRecordingIsOn)
           ?? false
       }
+      notifyRecordingAppend={currentMeeting?.notifyRecordingAppend ?? ''}
       serverTime={passedTime > 0 ? passedTime : 0}
       isModerator={currentUser?.isModerator ?? false}
       hasError={Boolean(currentMeetingErrors || meetingRecordingError)}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/notify/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/notify/component.tsx
@@ -42,6 +42,7 @@ interface RecordingNotifyModalProps {
   closeModal: () => void;
   isOpen: boolean;
   priority: string;
+  notifyRecordingAppend: string;
 }
 
 const RecordingNotifyModal: React.FC<RecordingNotifyModalProps> = ({
@@ -49,8 +50,10 @@ const RecordingNotifyModal: React.FC<RecordingNotifyModalProps> = ({
   closeModal,
   isOpen,
   priority,
+  notifyRecordingAppend,
 }) => {
   const [userLeaveMeeting] = useMutation(USER_LEAVE_MEETING);
+  const hasRecordingAppend = notifyRecordingAppend.trim().length > 0;
 
   const intl = useIntl();
   const skipButtonHandle = useCallback(() => {
@@ -76,6 +79,7 @@ const RecordingNotifyModal: React.FC<RecordingNotifyModalProps> = ({
   return (
     <Styled.RecordingNotifyModal
       contentLabel={intl.formatMessage(intlMessages.title)}
+      data-test="recordingNotifyModal"
       shouldShowCloseButton={false}
       title={intl.formatMessage(intlMessages.title)}
       {...{
@@ -85,12 +89,18 @@ const RecordingNotifyModal: React.FC<RecordingNotifyModalProps> = ({
       }}
     >
       <Styled.Container>
-        <Styled.Description>
+        <Styled.Description data-test="recordingNotifyDescription">
           {intl.formatMessage(intlMessages.description)}
+          {hasRecordingAppend ? (
+            <Styled.AppendDescription data-test="recordingNotifyAppend">
+              {notifyRecordingAppend}
+            </Styled.AppendDescription>
+          ) : null}
         </Styled.Description>
         <Styled.Footer>
           <Styled.NotifyButton
             color="primary"
+            dataTest="recordingNotifyContinue"
             label={intl.formatMessage(intlMessages.continue)}
             onClick={handleContinueInRecordedSession}
             aria-label={intl.formatMessage(intlMessages.continueAriaLabel)}

--- a/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/notify/styles.ts
+++ b/bigbluebutton-html5/imports/ui/components/nav-bar/nav-bar-graphql/recording-indicator/notify/styles.ts
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import ModalSimple from '/imports/ui/components/common/modal/simple/component';
 import ConfirmationModalStyles from '/imports/ui/components/common/modal/confirmation/styles';
+import { lgPaddingY } from '/imports/ui/stylesheets/styled-components/general';
 
 const RecordingNotifyModal = styled(ModalSimple)``;
 
@@ -10,6 +11,13 @@ const Container = styled(ConfirmationModalStyles.Container)`
 
 const Description = styled(ConfirmationModalStyles.Description)``;
 
+const AppendDescription = styled(ConfirmationModalStyles.DescriptionText)`
+  display: block;
+  margin-top: ${lgPaddingY};
+  overflow-wrap: anywhere;
+  word-break: break-word;
+`;
+
 const Footer = styled(ConfirmationModalStyles.Footer)``;
 
 const NotifyButton = styled(ConfirmationModalStyles.ConfirmationButton)``;
@@ -18,6 +26,7 @@ export default {
   RecordingNotifyModal,
   Container,
   Description,
+  AppendDescription,
   Footer,
   NotifyButton,
 };

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -202,6 +202,10 @@ export const elements = {
   reconnectingBar: '//div[@data-test="notificationBannerBar" and contains(text(), "Reconnection in progress")]',
   zoomInBtn: 'button[data-test="zoomInBtn"]',
   recordingIndicator: 'div[data-test="recordingIndicator"]',
+  recordingNotifyModal: 'div[data-test="recordingNotifyModal"]',
+  recordingNotifyDescription: 'div[data-test="recordingNotifyDescription"]',
+  recordingNotifyAppend: 'span[data-test="recordingNotifyAppend"]',
+  recordingNotifyContinue: 'button[data-test="recordingNotifyContinue"]',
   webcamMirroredVideoContainer: 'video[data-test="mirroredVideoContainer"]',
   currentUserLocalStreamVideo: 'video[data-local-stream="true"]',
   usersList: 'div[data-test="userList"]',
@@ -292,6 +296,7 @@ export const elements = {
   raisingHandToast: 'You have raised your hand',
   loweringHandToast: 'Your hand has been lowered',
   noActiveMicrophoneToast: 'No active microphone. Share your microphone to add audio to this recording.',
+  recordingNotifyDefaultText: 'A recording will be available based on the remainder of this session',
   whiteboardAvailableToast: 'The whiteboard is now available',
   whiteboardDisabledToast: 'The whiteboard access has been removed',
   // Icons

--- a/bigbluebutton-tests/playwright/parameters/constants.ts
+++ b/bigbluebutton-tests/playwright/parameters/constants.ts
@@ -23,7 +23,9 @@ export const constants = {
   lockSettingsDisablePublicChat: 'lockSettingsDisablePublicChat=true',
   lockSettingsHideUserList: 'lockSettingsHideUserList=true',
   allowModsToEjectCameras: 'allowModsToEjectCameras=true',
-  notifyRecordingIsOn: 'notifyRecordingIsOn=true&notifyRecordingIsOn=true',
+  notifyRecordingIsOn: 'notifyRecordingIsOn=true',
+  notifyRecordingAppendMessage: 'This meeting will be summarized using AI — <strong>plain text</strong>',
+  notifyRecordingAppend: 'notifyRecordingAppend=This meeting will be summarized using AI — <strong>plain text</strong>',
   preUploadedPresentation:
     'preUploadedPresentation=https://raw.githubusercontent.com/bigbluebutton/bigbluebutton/v3.0.x-develop/bigbluebutton-tests/playwright/core/media/sample.pdf',
   preUploadedPresentationOverrideDefault: 'preUploadedPresentationOverrideDefault=true',

--- a/bigbluebutton-tests/playwright/parameters/createParameters.ts
+++ b/bigbluebutton-tests/playwright/parameters/createParameters.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 
-import { ELEMENT_WAIT_TIME, VIDEO_LOADING_WAIT_TIME } from '../core/constants';
+import { ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME, LOOP_INTERVAL, VIDEO_LOADING_WAIT_TIME } from '../core/constants';
 import { elements as e } from '../core/elements';
 import { checkDefaultLocationReset, checkScreenshots } from '../layouts/util';
 import { MultiUsers } from '../user/multiusers';
@@ -11,6 +11,65 @@ const { messageModerator } = constants;
 export class CreateParameters extends MultiUsers {
   async recordMeeting() {
     await this.modPage.hasElement(e.recordingIndicator, 'should the recording indicator to be displayed');
+  }
+
+  async recordingNotificationAppend(expectedAppend?: string, shouldShowModal = true) {
+    await this.modPage.waitForSelector(e.whiteboard, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.waitAndClick(e.recordingIndicator);
+    await this.modPage.hasElement(e.yesButton, 'should display the button to start recording');
+    await this.modPage.waitAndClick(e.yesButton);
+
+    const userRecordingStatus = this.userPage.page.locator(`${e.recordingIndicator} > div`);
+    await expect(
+      userRecordingStatus,
+      'should show recording as started for the attendee before checking the consent modal',
+    ).toHaveCSS('background-color', 'rgb(174, 16, 16)', { timeout: ELEMENT_WAIT_LONGER_TIME });
+
+    if (!shouldShowModal) {
+      // Give the recording-change effects time to run before asserting that the gate suppressed the modal.
+      await this.userPage.page.waitForTimeout(LOOP_INTERVAL);
+      await this.userPage.wasRemoved(
+        e.recordingNotifyModal,
+        'should not display recording consent when notifyRecordingIsOn is disabled',
+      );
+      return;
+    }
+
+    await this.userPage.hasElement(
+      e.recordingNotifyModal,
+      'should display the recording consent modal for the attendee',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+    await this.userPage.hasText(
+      e.recordingNotifyDescription,
+      e.recordingNotifyDefaultText,
+      'should preserve the default recording consent description',
+    );
+    await this.modPage.wasRemoved(
+      e.recordingNotifyModal,
+      'should not display the recording consent modal for the user who started recording',
+    );
+
+    if (expectedAppend) {
+      await expect(
+        this.userPage.page.locator(e.recordingNotifyAppend),
+        'should append the custom recording consent text',
+      ).toHaveText(expectedAppend);
+      await expect(
+        this.userPage.page.locator(e.recordingNotifyAppend).locator('strong'),
+        'should render markup-like append content as escaped plain text',
+      ).toHaveCount(0);
+      await this.userPage.waitAndClick(e.recordingNotifyContinue);
+      await this.userPage.wasRemoved(
+        e.recordingNotifyModal,
+        'should close the recording consent modal after the attendee continues',
+      );
+    } else {
+      await this.userPage.wasRemoved(
+        e.recordingNotifyAppend,
+        'should not render an appended-text block when the parameter is empty',
+      );
+    }
   }
 
   async bannerText() {

--- a/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
+++ b/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
@@ -13,6 +13,41 @@ test.describe.parallel('Create Parameters', { tag: '@ci' }, () => {
     await createParam.recordMeeting();
   });
 
+  test.describe.parallel('Recording notification consent', () => {
+    test('Appends escaped custom text to the consent modal', async ({ browser, context, page }, testInfo) => {
+      linkIssue(25579);
+      const createParam = new CreateParameters(browser, context);
+      await createParam.initModPage(page, {
+        createParameter: `${c.recordMeeting}&${c.notifyRecordingIsOn}&${encodeCustomParams(c.notifyRecordingAppend)}`,
+        testInfo,
+      });
+      await createParam.initUserPage(context, { testInfo });
+      await createParam.recordingNotificationAppend(c.notifyRecordingAppendMessage);
+    });
+
+    test('Keeps the existing modal unchanged for an empty append', async ({ browser, context, page }, testInfo) => {
+      linkIssue(25579);
+      const createParam = new CreateParameters(browser, context);
+      await createParam.initModPage(page, {
+        createParameter: `${c.recordMeeting}&${c.notifyRecordingIsOn}&notifyRecordingAppend=`,
+        testInfo,
+      });
+      await createParam.initUserPage(context, { testInfo });
+      await createParam.recordingNotificationAppend();
+    });
+
+    test('Does not enable consent notifications by itself', async ({ browser, context, page }, testInfo) => {
+      linkIssue(25579);
+      const createParam = new CreateParameters(browser, context);
+      await createParam.initModPage(page, {
+        createParameter: `${c.recordMeeting}&${encodeCustomParams(c.notifyRecordingAppend)}`,
+        testInfo,
+      });
+      await createParam.initUserPage(context, { testInfo });
+      await createParam.recordingNotificationAppend(undefined, false);
+    });
+  });
+
   test.describe.parallel('Banner', () => {
     test('Banner Text', async ({ browser, context, page }, testInfo) => {
       const createParam = new CreateParameters(browser, context);

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1602,7 +1602,7 @@ These configs can be set in `/etc/bigbluebutton/bbb-web.properties`. The table i
 
 #### `/create` parameters without a `bigbluebutton.properties` counterpart
 
-Some `/create` parameters set per-meeting state but have no default in `bigbluebutton.properties`. Examples include `name`, `meetingID`, `parentMeetingID`/`sequence`/`freeJoin`/`isBreakout` (breakout-only), `bannerText`/`bannerColor`, `moderatorOnlyMessage`, `meta_*` metadata, `logo`, `multiUserWhiteboardEnabled`, presentation-upload parameters (`preUploadedPresentation*`, `presentationUploadExternalUrl`, `presentationUploadExternalDescription`), `sharedNotesInitialContentJsonUrl`, `disabledFeaturesExclude`, `clientSettingsOverride` / `clientSettingsOverrideJsonUrl`, and `pluginManifestsFetchUrl`. See [Create API parameters](/development/api/#create) for the complete list and descriptions.
+Some `/create` parameters set per-meeting state but have no default in `bigbluebutton.properties`. Examples include `name`, `meetingID`, `parentMeetingID`/`sequence`/`freeJoin`/`isBreakout` (breakout-only), `bannerText`/`bannerColor`, `moderatorOnlyMessage`, `notifyRecordingAppend`, `meta_*` metadata, `logo`, `multiUserWhiteboardEnabled`, presentation-upload parameters (`preUploadedPresentation*`, `presentationUploadExternalUrl`, `presentationUploadExternalDescription`), `sharedNotesInitialContentJsonUrl`, `disabledFeaturesExclude`, `clientSettingsOverride` / `clientSettingsOverrideJsonUrl`, and `pluginManifestsFetchUrl`. See [Create API parameters](/development/api/#create) for the complete list and descriptions.
 
 
 #### Passing user metadata to the client on join

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -639,6 +639,12 @@ const createEndpointTableData = [
     "description": (<>If it is true, a modal will be displayed to collect recording consent from users when meeting recording starts (only if <code className="language-plaintext highlighter-rouge">notifyRecordingIsOn=true</code>). By default it is false. (added 2.6)</>)
   },
   {
+    "name": "notifyRecordingAppend",
+    "required": false,
+    "type": "String",
+    "description": (<>Optional plain-text message appended after the standard recording notification description. It is shown only when recording notifications are enabled with <code className="language-plaintext highlighter-rouge">notifyRecordingIsOn=true</code>. If omitted or empty, the dialog is unchanged. HTML is displayed as text. (added 3.0.36)</>)
+  },
+  {
     "name": "presentationUploadExternalUrl",
     "required": false,
     "type": "String",

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -117,7 +117,7 @@ Updated in 2.7:
 Updated in 3.0:
 
 - **create**
-  - **Added parameters:** `loginURL`, `pluginManifests`, `pluginManifestsFetchUrl`, `presentationConversionCacheEnabled`, `maxNumPages`, `multiUserWhiteboardEnabled`, `clientSettingsOverrideJsonUrl`, `sharedNotesEditor`, `sharedNotesInitialContentJsonUrl` (3.0.25), `sharedNotesInitialContentMarkdown` (3.0.33), `sharedNotesInitialContentMarkdownUrl` (3.0.33), `cameraBridge`, `screenShareBridge`, `audioBridge`, `darklogo`.
+  - **Added parameters:** `loginURL`, `pluginManifests`, `pluginManifestsFetchUrl`, `presentationConversionCacheEnabled`, `maxNumPages`, `multiUserWhiteboardEnabled`, `clientSettingsOverrideJsonUrl`, `sharedNotesEditor`, `sharedNotesInitialContentJsonUrl` (3.0.25), `sharedNotesInitialContentMarkdown` (3.0.33), `sharedNotesInitialContentMarkdownUrl` (3.0.33), `notifyRecordingAppend` (3.0.36), `cameraBridge`, `screenShareBridge`, `audioBridge`, `darklogo`.
   - **Added options:** Parameter `meetingLayout` supports a few new options: CAMERAS_ONLY, PARTICIPANTS_AND_CHAT_ONLY, PRESENTATION_ONLY, MEDIA_ONLY;
   - **Added options:** Parameter `disabledFeatures` supports a few new options: `infiniteWhiteboard`, `deleteChatMessage`, `editChatMessage`, `replyChatMessage`, `chatMessageReactions`, `raiseHand`, `userReactions`, `chatEmojiPicker`, `quizzes`;
   - **Added POST module:** `clientSettingsOverride` (gated by the server-side setting `allowOverrideClientSettingsOnCreateCall` in `bbb-web.properties`);


### PR DESCRIPTION
### What does this PR do?

Ports #25603 changes to 3.0

_Introduces the optional /create parameter notifyRecordingAppend._
_When notifyRecordingIsOn=true, its plain-text value is displayed beneath the recording consent message._