### PR TITLE
[3.0 presentation toolbar] fix: darkmode-aware CSS for infinite WB button

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/presentation/presentation-toolbar/container.jsx
@@ -31,17 +31,17 @@ const infiniteWhiteboardIcon = (isinfiniteWhiteboard) => {
              3.14924 14.8508 3 14.6667 3ZM1.33333 2C0.596954 2 0 2.59695 0 3.33333V13.3333C0 14.0697
              0.596953 14.6667 1.33333 14.6667H14.6667C15.403 14.6667 16 14.0697 16 13.3333V3.33333C16
              2.59695 15.403 2 14.6667 2H1.33333Z"
-          fill="#4E5A66"
+          fill="currentColor"
         />
         <path
           d="M12.875 11.875L9.125 8.125M9.125 8.125L9.125 10.9375M9.125 8.125L11.9375 8.125"
-          stroke="#4E5A66"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
         <path
           d="M3.125 5.125L6.875 8.875M6.875 8.875L6.875 6.0625M6.875 8.875L4.0625 8.875"
-          stroke="#4E5A66"
+          stroke="currentColor"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
@@ -64,17 +64,17 @@ const infiniteWhiteboardIcon = (isinfiniteWhiteboard) => {
              3.14924 14.8508 3 14.6667 3ZM1.33333 2C0.596954 2 0 2.59695 0 3.33333V13.3333C0 14.0697
              0.596953 14.6667 1.33333 14.6667H14.6667C15.403 14.6667 16 14.0697 16 13.3333V3.33333C16
              2.59695 15.403 2 14.6667 2H1.33333Z"
-        fill="#4E5A66"
+        fill="currentColor"
       />
       <path
         d="M9.125 8.125L12.875 11.875M12.875 11.875L12.875 9.0625M12.875 11.875L10.0625 11.875"
-        stroke="#4E5A66"
+        stroke="currentColor"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <path
         d="M6.875 8.875L3.125 5.125M3.125 5.125L3.125 7.9375M3.125 5.125L5.9375 5.125"
-        stroke="#4E5A66"
+        stroke="currentColor"
         strokeLinecap="round"
         strokeLinejoin="round"
       />


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
This makes infinite WB button "darkmode-aware".


### Motivation
Currently the foreground color of infinite WB button is fixed to #4E5A66, which in the darkmode is not very visible. Users might misunderstand it's disabled.

Current CSS [Light mode]
<img width="298" height="58" alt="スクリーンショット 2026-08-29 19 51 07" src="https://github.com/user-attachments/assets/784dc0e7-6b97-465e-89b8-c6816c595949" />

Current CSS [Dark mode]
<img width="298" height="58" alt="スクリーンショット 2026-08-29 19 50 53" src="https://github.com/user-attachments/assets/843bfdf8-8d3e-408f-9f79-49b6d9b10c27" />

This PR changes the fg color to "currentColor". The button will then look like:
<img width="298" height="58" alt="スクリーンショット 2026-08-29 19 51 26" src="https://github.com/user-attachments/assets/316d97e2-a399-4901-a82a-5da0eba6d7ae" />
in the dark mode.

### More
I didn't find a clear reason why only this button is drawn as SVG, but not assigned from BBB-font set.