### PR TITLE
[4.0] build(freeswitch): v1.11.3 (up from v1.11.2)

### DIFF
--- a/freeswitch.placeholder.sh
+++ b/freeswitch.placeholder.sh
@@ -4,5 +4,5 @@ mkdir freeswitch
 cd freeswitch
 git init
 git remote add origin https://github.com/signalwire/freeswitch.git
-git fetch --depth 1 origin v1.11.2
+git fetch --depth 1 origin v1.11.3
 git checkout FETCH_HEAD


### PR DESCRIPTION
### What does this PR do?

- [build(freeswitch): v1.11.3 (up from v1.11.2)](https://github.com/bigbluebutton/bigbluebutton/commit/81a70f391c288e24ea54ce6403bdcb4456cefa9b) 
  - Bump FreeSWITCH to v1.11.3, see https://github.com/signalwire/freeswitch/releases/tag/v1.11.3

### Closes Issue(s)

None