### PR TITLE
docs: iteration doc sync for 4.0.0-rc.1 (since 4.0.0-beta.5)

### DIFF
--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -1785,7 +1785,7 @@ These configs can be set in `/etc/bigbluebutton/bbb-web.properties`. The table i
 | `breakoutRoomsRecord` | Enable recordings in breakout rooms | true/false | false _`overwritable`_ |
 | `breakoutRoomsPrivateChatEnabled` | Enable private chat in breakout rooms | true/false | true _`overwritable`_ |
 | `breakoutRoomsMultiUserWhiteboardDefaultOn` | Enable multi-user whiteboard by default in breakout rooms | true/false | true |
-| `learningDashboardCleanupDelayInMinutes` | Minutes the Learning Dashboard remains available after the meeting ends | Integer (0=keep permanently) | 2 _`overwritable`_ |
+| `learningDashboardCleanupDelayInMinutes` | Minutes the Learning Dashboard remains available after the meeting ends. For a breakout room's dashboard, the countdown starts when the parent meeting ends | Integer (0=keep permanently) | 2 _`overwritable`_ |
 | `disabledFeatures` | Comma-separated list of features to disable (see [`/create` docs](/development/api/#create) for the full list of feature names) | csv | _(empty)_ _`overwritable`_ |
 | `sharedNotesEditor` | Type of shared notes editor to use. Control characters and surrounding whitespace are stripped, values are case-insensitive, and invalid configured defaults fall back to `blockNote`. | etherpad, blockNote | blockNote _`overwritable`_ |
 | `maxSharedNotesInitialContentUrlPayloadSize` | Maximum size (in KiB) of the response fetched when seeding shared-notes initial content from `sharedNotesInitialContentJsonUrl` / `sharedNotesInitialContentMarkdownUrl` | Integer (KiB) | 1024 |

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -333,7 +333,7 @@ const createEndpointTableData = [
     "required": false,
     "type": "Boolean",
     "default": false,
-    "description": (<>Defaults to the value of <code className="language-plaintext highlighter-rouge">defaultKeepEvents</code>. If <code className="language-plaintext highlighter-rouge">meetingKeepEvents</code> is true BigBlueButton saves meeting events even if the meeting is not recorded (added in 2.3)</>)
+    "description": (<>Defaults to the value of <code className="language-plaintext highlighter-rouge">defaultKeepEvents</code>. If <code className="language-plaintext highlighter-rouge">meetingKeepEvents</code> is true BigBlueButton saves meeting events even if the meeting is not recorded (added in 2.3)<p><i>Updated in 4.0:</i> breakout rooms inherit the parent meeting's value instead of falling back to <code className="language-plaintext highlighter-rouge">defaultKeepEvents</code>.</p></>)
   },
   {
     "name": "endWhenNoModerator",

--- a/docs/docs/data/create.tsx
+++ b/docs/docs/data/create.tsx
@@ -333,7 +333,7 @@ const createEndpointTableData = [
     "required": false,
     "type": "Boolean",
     "default": false,
-    "description": (<>Defaults to the value of <code className="language-plaintext highlighter-rouge">defaultKeepEvents</code>. If <code className="language-plaintext highlighter-rouge">meetingKeepEvents</code> is true BigBlueButton saves meeting events even if the meeting is not recorded (added in 2.3)<p><i>Updated in 4.0:</i> breakout rooms inherit the parent meeting's value instead of falling back to <code className="language-plaintext highlighter-rouge">defaultKeepEvents</code>.</p></>)
+    "description": (<>Defaults to the value of <code className="language-plaintext highlighter-rouge">defaultKeepEvents</code>. If <code className="language-plaintext highlighter-rouge">meetingKeepEvents</code> is true BigBlueButton saves meeting events even if the meeting is not recorded (added in 2.3)<p><i>Updated in 4.0:</i> breakout rooms always use the parent meeting's effective <code className="language-plaintext highlighter-rouge">meetingKeepEvents</code> value; an explicit parameter and the <code className="language-plaintext highlighter-rouge">defaultKeepEvents</code> fallback only apply to top-level meetings.</p></>)
   },
   {
     "name": "endWhenNoModerator",

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -142,6 +142,7 @@ Updated in 4.0:
   - **Removed parameter:** `webVoice` (obsolete; it selected a separate voice conference for the old Flash client and had no downstream effect after that client was removed in BBB 2.3, always falling back to `voiceBridge`).
   - **Changed:** Parameter `meetingLayout` default is now `UNIFIED_LAYOUT`. **Removed:** `meetingLayout` no longer supports `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS`. The remaining non-default options targeting hybrid/niche scenarios are `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY`.
   - **Changed:** Parameter `sharedNotesEditor` now strips control characters and surrounding whitespace, accepts `etherpad` or `blockNote` case-insensitively, canonicalizes known values, and rejects unknown values.
+  - **Changed:** Breakout rooms now inherit the parent meeting's `meetingKeepEvents` value (previously they always fell back to the server-wide `defaultKeepEvents`, even when the parent had an explicit override).
   - **Removed option:** `layouts` is no longer a valid `disabledFeatures` value (the layout selection UI was removed).
 - **join**
   - **Changed:** Parameter `enforceLayout` accepted values are now `UNIFIED_LAYOUT`, `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY` (the deprecated `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS` are no longer accepted).

--- a/docs/docs/development/api.md
+++ b/docs/docs/development/api.md
@@ -142,7 +142,7 @@ Updated in 4.0:
   - **Removed parameter:** `webVoice` (obsolete; it selected a separate voice conference for the old Flash client and had no downstream effect after that client was removed in BBB 2.3, always falling back to `voiceBridge`).
   - **Changed:** Parameter `meetingLayout` default is now `UNIFIED_LAYOUT`. **Removed:** `meetingLayout` no longer supports `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS`. The remaining non-default options targeting hybrid/niche scenarios are `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY`.
   - **Changed:** Parameter `sharedNotesEditor` now strips control characters and surrounding whitespace, accepts `etherpad` or `blockNote` case-insensitively, canonicalizes known values, and rejects unknown values.
-  - **Changed:** Breakout rooms now inherit the parent meeting's `meetingKeepEvents` value (previously they always fell back to the server-wide `defaultKeepEvents`, even when the parent had an explicit override).
+  - **Changed:** Breakout rooms now always inherit the parent meeting's effective `meetingKeepEvents` value; an explicit `meetingKeepEvents` parameter and the server-wide `defaultKeepEvents` fallback only apply to top-level meetings (previously breakouts always fell back to `defaultKeepEvents`, even when the parent had an explicit override).
   - **Removed option:** `layouts` is no longer a valid `disabledFeatures` value (the layout selection UI was removed).
 - **join**
   - **Changed:** Parameter `enforceLayout` accepted values are now `UNIFIED_LAYOUT`, `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, `MEDIA_ONLY` (the deprecated `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, `VIDEO_FOCUS` are no longer accepted).

--- a/docs/docs/new-features.md
+++ b/docs/docs/new-features.md
@@ -58,7 +58,7 @@ The client now follows the operating system's light/dark preference (`prefers-co
 
 Audio settings moved into a dedicated **Audio** tab in the Settings modal, where each user picks how their microphone signal is processed before it is sent to other participants:
 
-- **Advanced Filtering** - an optional WASM-based audio processor (internally "BBBA") that runs on top of the microphone stream, isolating the speaker's voice and eliminating background noise. It is disabled by default and has to be made available by the administrator; see [Advanced Filtering (WASM audio processing)](/administration/customize#advanced-filtering-wasm-audio-processing) for configuration details.
+- **Advanced Filtering** - an optional WASM-based audio processor that runs on top of the microphone stream, isolating the speaker's voice and eliminating background noise. Two interchangeable backends are available, selected by the administrator via `public.media.audio.audioWasmProcessing.provider`: `bbba` (the default) and `workadventureDtln` (DTLN noise suppression as used by WorkAdventure). It is disabled by default and has to be made available by the administrator; see [Advanced Filtering (WASM audio processing)](/administration/customize#advanced-filtering-wasm-audio-processing) for configuration details.
 - **Standard Filtering** (default) - the browser's built-in filters: auto gain control, echo cancellation, and noise suppression.
 - **Original Audio** - no processing at all; the raw microphone signal is transmitted. Ideal for sharing music, singing, or instruments.
 
@@ -71,6 +71,10 @@ The mode pre-selected for a new user is controlled by `public.app.defaultSetting
 When browser-based (WebSpeech) live captions are enabled and a user holds the audio floor but no transcription is produced for a short while, BigBlueButton now shows a toast suggesting the wrong microphone may be selected or the environment is too noisy. The alert can optionally link to a knowledge-base article and is configurable via `public.app.audioCaptions.microphoneAlert` in `settings.yml`.
 
 <!-- TODO add screenshot of the wrong-microphone caption alert -->
+
+#### Whiteboard: scroll to pan, Ctrl+scroll to zoom
+
+Scrolling the mouse wheel over the whiteboard now pans the presentation, and holding `Ctrl` (`Cmd` on macOS) while scrolling zooms in and out - matching the navigation model of most design tools.
 
 ### Engagement
 
@@ -105,6 +109,10 @@ A new **Multi-Functional Mode** adds an auxiliary sidebar content panel, allowin
 A chat message that contains only emoji (up to three emoji, whitespace ignored) is now rendered at a larger font size — matching the "jumbomoji" behavior familiar from popular messengers. Messages with any accompanying text keep the normal size.
 
 <!-- TODO add screenshot of a jumbomoji chat message -->
+
+#### Learning Dashboard for breakout rooms
+
+The Learning Dashboard is no longer disabled in breakout rooms: each breakout gets its own dashboard, tracking activity the same way the parent meeting does (an inherited `disabledFeatures=learningDashboard` still turns it off). A breakout's dashboard data is also kept until the *parent* meeting ends - previously cleanup was anchored to the breakout's own end - so instructors can review breakout activity for as long as the main room is running (plus `learningDashboardCleanupDelayInMinutes`).
 
 <!-- ### Analytics -->
 
@@ -178,6 +186,14 @@ via the bbb-webrtc-recorder application. If `livekit/egress` was previously
 installed in a server, any steps done to enable it should be reverted. Refer to
 the [previous installations steps](https://github.com/bigbluebutton/bigbluebutton/blob/6eab874ffa8d0e82453dad3b06621dea16e15e6d/docs/docs/new-features.md?plain=1#L209-L237).
 
+Listening into a breakout room from the parent meeting is now supported on the
+LiveKit bridge, at feature parity with the FreeSWITCH/mediasoup transfer flow.
+A moderator using the breakout panel's listen action is switched into the
+breakout's audio - mute/unmute applies to the breakout while listening - and gets
+a persistent toast naming the room, with a "Return to main room" button. Under
+the hood this is built on a new membership-based LiveKit token model, which also
+brings automatic token refresh for long-running sessions.
+
 We encourage users to provide feedback via our GitHub issue tracker or the mailing
 lists.
 
@@ -197,6 +213,7 @@ For full details on what is new in BigBlueButton 4.0, see the release notes.
 
 Recent releases:
 
+- [4.0.0-rc.1](https://github.com/bigbluebutton/bigbluebutton/releases/tag/v4.0.0-rc.1)
 - [4.0.0-beta.5](https://github.com/bigbluebutton/bigbluebutton/releases/tag/v4.0.0-beta.5)
 - [4.0.0-beta.4](https://github.com/bigbluebutton/bigbluebutton/releases/tag/v4.0.0-beta.4)
 - [4.0.0-beta.3](https://github.com/bigbluebutton/bigbluebutton/releases/tag/v4.0.0-beta.3)
@@ -268,7 +285,7 @@ The deprecated REST endpoint `/api/rest/clientSettings` has been removed. Client
 #### Value changed
 
 - `defaultMeetingLayout` default changed from `CUSTOM_LAYOUT` to `UNIFIED_LAYOUT`. Accepted values are now `UNIFIED_LAYOUT` (default), plus the hybrid/niche options `CAMERAS_ONLY`, `PARTICIPANTS_AND_CHAT_ONLY`, `PRESENTATION_ONLY`, and `MEDIA_ONLY`. The previous values `CUSTOM_LAYOUT`, `SMART_LAYOUT`, `PRESENTATION_FOCUS`, and `VIDEO_FOCUS` are no longer accepted.
-- `html5PluginSdkVersion` bumped from `0.1.17` to `0.1.24`.
+- `html5PluginSdkVersion` bumped from `0.1.17` to `0.1.26`.
 - `disabledFeatures` accepts a new value: `pinChatMessage` (alongside the existing chat-related options).
 - `sharedNotesEditor` default changed from `etherpad` to `blockNote` (BlockNote is now the default shared-notes editor; see [Promoted BlockNote shared notes as default](#promoted-blocknote-shared-notes-as-default)).
 - `cameraBridge`, `screenShareBridge`, and `audioBridge` default changed from `bbb-webrtc-sfu` to `livekit` (see [LiveKit is the default media framework](#livekit-is-the-default-media-framework)).
@@ -285,6 +302,7 @@ These changes apply to the client configuration file (`/etc/bigbluebutton/bbb-ht
 
 #### Added
 
+- `public.kurento.pagination.gridEnabled` (default `true`) - whether the camera-less avatar grid (the "webcam grid") is shown while the presentation is minimized. The grid can also be disabled per meeting with `disabledFeatures=webcamGrid`.
 - `public.multiFunctionalMode.enabled` (default `false`) - enables the auxiliary/dual sidebar content panel.
 - `public.userList.searchBar.enabled` (default `true`) - enables the user list search field.
 - `public.app.appsGallery.maxPinnedApps` (default `3`) - maximum number of apps a user can pin in the Apps Gallery.


### PR DESCRIPTION
### What does this PR do?

Brings the 4.0 documentation up to date with the `v4.0.0-beta.5..v4.0.x-develop` delta (101 non-merge commits) ahead of the 4.0.0-rc.1 cut. Items already documented during the iteration (webcamGrid `disabledFeatures` option, `logoutTimer` / `allowDuplicateExtUserid` removals, `sharedNotesEditor` validation, `sendChatMessage` error table) are not repeated.

**`docs/docs/new-features.md`**
- LiveKit section: documents breakout listen-in on the LiveKit bridge (feature parity with the FreeSWITCH transfer flow), built on the membership-based token model with automatic token refresh (cb4767a366, 1508f2bd02, 33b7b9b8f0, d9f3172da2)
- Engagement: Learning Dashboard for breakout rooms, with dashboard data now kept until the parent meeting ends (9a03581a12)
- Usability: whiteboard scroll-to-pan, Ctrl/Cmd+scroll to zoom (98779d8e72)
- Dedicated Audio settings tab: generalized the "BBBA" wording to the pluggable WASM provider model - `provider: bbba` (default) or `workadventureDtln` (9f1f11d246, 814f3ab12c)
- Client settings ledger: added `public.kurento.pagination.gridEnabled` (40da80460a); `html5PluginSdkVersion` 0.1.24 -> 0.1.26
- Recent releases: added the 4.0.0-rc.1 release-notes link

**`docs/docs/development/api.md` and `docs/docs/data/create.tsx`**
- create "Updated in 4.0": breakout rooms now inherit the parent meeting's `meetingKeepEvents` instead of falling back to the server-wide `defaultKeepEvents` (2b18e2fcd6), with a matching "Updated in 4.0" note on the parameter row

**`docs/docs/administration/customize.md`**
- `learningDashboardCleanupDelayInMinutes`: noted that a breakout dashboard's countdown starts when the parent meeting ends

### Closes Issue(s)

None - routine docs sync for the release iteration.

### Motivation

The 4.0.0-rc.1 release is about to be cut; the docs should describe everything that landed since 4.0.0-beta.5.

### How to test

- `cd docs && npm ci && npx docusaurus build` - the build passes with `onBrokenLinks: 'throw'`, which validates all links and anchors added here.
- Review the rendered pages: New features (Usability, Engagement, LiveKit section, settings ledgers), API create reference (`meetingKeepEvents` row, "Updated in 4.0" block), and the bbb-web properties table in Customize.
- Cross-reference claims against the source commits listed above; `akka-bbb-apps/application.conf` had no changes in this range.

### More

- [x] Added/updated documentation

Note: the "Recent releases" link for 4.0.0-rc.1 will 404 until the GitHub release is published - added intentionally so the docs don't need a follow-up commit at release time.
