### PR TITLE
fix(whiteboard): exit shape editing synchronously on slide change

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx
@@ -2281,6 +2281,14 @@ const Whiteboard = React.memo((props) => {
     let cancelled = false;
     const currentPageId = `page:${formattedPageId}`;
 
+    // A viewer mid-edit must leave select.editing_shape before anything prunes the old
+    // page's shapes. The same check inside applyPageSwap runs too late now that the swap
+    // is decode-gated: the shapes-sync removal effects are unguarded and run during the
+    // decode wait (issue 25332).
+    if (tlEditorRef.current.getEditingShape()) {
+      tlEditorRef.current.complete();
+    }
+
     // Create the new page + its camera record synchronously, before the gate. These records
     // are invisible (nothing renders until setCurrentPage runs in applyPageSwap), but remote
     // annotations for the new page arrive via debouncedUpdateShapes (service.js, 175ms)


### PR DESCRIPTION
## What does this PR do?

Commits a viewer's in-progress whiteboard edit synchronously at the top of the
`[curPageId]` effect, before the decode gate starts, so tldraw leaves
`select.editing_shape` while the shape being edited still exists. The existing
check inside `applyPageSwap` is kept as a second line of defense for an edit
that begins during the decode wait.

## Why

This is a timing regression of #25332 (fixed in #25345), re-opened by the
decode-gated slide swap from #25493.

- #25345 fixed the crash by committing the in-progress edit inside the
  `[curPageId]` page swap, immediately before the store mutation that removes
  the old page's shapes.
- #25493 then deferred that whole swap - guard included - behind an
  `img.decode()` race, to stop the white flash on slide change (#25397).
- The shapes-sync removal effects (`[removedShapes]` and the shapes-diff
  pruning) are unguarded and still run immediately. When the viewer's shape
  subscription re-keys to the new page before the decode resolves, the edited
  shape is removed while the editor still holds a dangling `editingShapeId`.
  The viewer's next pointer-down trips tldraw's `Expected an editing shape!`
  assertion and crashes the client - the exact crash #25345 addressed, now
  dependent on the subscription-update vs SVG-decode race.

The race usually resolves the safe way (decode wins), which is why CI stayed
green until the `No crash on slide change while a viewer is editing`
regression test caught it on a loaded runner in #25723 - a test-only PR that
cannot itself have introduced a client crash.

## How to reproduce / verify

1. Presenter grants multi-user whiteboard access.
2. Viewer picks the text tool, clicks the canvas and types, staying mid-edit.
3. Presenter advances the slide; viewer clicks the canvas afterwards.
4. Without this fix the viewer client can crash with
   `Expected an editing shape!` (more likely with a cold asset cache or a
   slow/loaded machine, which widens the decode window).
5. The Playwright regression test covering this is
   `whiteboard/whiteboard.spec.ts > Whiteboard tools > No crash on slide
   change while a viewer is editing`.

## Notes

- 8-line change in
  `bigbluebutton-html5/imports/ui/components/whiteboard/component.jsx`.
- The full mechanism analysis is in the commit message body.

Related: #25332, #25345, #25493, #25397, #25723
