### PR TITLE
fix: widen meeting_group groupId and name columns to text

### DIFF
--- a/bbb-graphql-server/bbb_schema.sql
+++ b/bbb-graphql-server/bbb_schema.sql
@@ -249,9 +249,9 @@ from (
 
 create unlogged table "meeting_group" (
 	"meetingId"  varchar(100) references "meeting"("meetingId") ON DELETE CASCADE,
-    "groupId"    varchar(100),
+    "groupId"    text,
     "groupIndex" integer,
-    "name"       varchar(100),
+    "name"       text,
     "usersExtId" varchar[],
     CONSTRAINT "meeting_group_pkey" PRIMARY KEY ("meetingId","groupId")
 );

--- a/bigbluebutton-tests/playwright/parameters/constants.ts
+++ b/bigbluebutton-tests/playwright/parameters/constants.ts
@@ -4,6 +4,14 @@ import { parameters } from '../core/parameters';
 export const CUSTOM_STYLE_CSS = `${e.presentationTitle}{display: none;}`;
 export const CUSTOM_STYLE_URL = 'http://bbb-test-stub.local/css-test-file.css';
 
+// group names around the old varchar(100) limit of meeting_group (issue 25676)
+export const LONG_GROUP_NAMES = {
+  control: 'Control Group',
+  chars150: 'G'.repeat(150),
+  boundary100: 'H'.repeat(100),
+  boundary101: 'I'.repeat(101),
+};
+
 const serverOrigin = parameters.server ? new URL(parameters.server).origin : '';
 
 export const constants = {
@@ -50,6 +58,12 @@ export const constants = {
   enforceMediaOnly: 'enforceLayout=MEDIA_ONLY',
   groups:
     'groups=[{"id":"1","name":"Room 1","roster":["1235"]},{"id":"2","name":"Room 2","roster":["2333","2335"]},{"id":"3","roster":[]}]',
+  groupsWithLongNames: `groups=${JSON.stringify([
+    { id: 'groupControl', name: LONG_GROUP_NAMES.control, roster: ['1235'] },
+    { id: 'g'.repeat(150), name: LONG_GROUP_NAMES.chars150, roster: [] },
+    { id: 'groupBoundary100', name: LONG_GROUP_NAMES.boundary100, roster: [] },
+    { id: 'groupBoundary101', name: LONG_GROUP_NAMES.boundary101, roster: [] },
+  ])}`,
   // Custom Parameters
   autoJoin: 'userdata-bbb_auto_join_audio=false',
   listenOnlyMode: 'userdata-bbb_listen_only_mode=false',

--- a/bigbluebutton-tests/playwright/parameters/customparameters.ts
+++ b/bigbluebutton-tests/playwright/parameters/customparameters.ts
@@ -12,7 +12,7 @@ import { checkDefaultLocationReset, checkScreenshots } from '../layouts/util';
 import { uploadSinglePresentation } from '../presentation/util';
 import * as utilScreenShare from '../screenshare/util';
 import { MultiUsers } from '../user/multiusers';
-import { constants as c } from './constants';
+import { constants as c, LONG_GROUP_NAMES } from './constants';
 import * as util from './util';
 
 export class CustomParameters extends MultiUsers {
@@ -963,6 +963,46 @@ export class CustomParameters extends MultiUsers {
       e.userNameBreakoutRoom,
       /Attendee/,
       'should have the attendee name on the breakout room below a room on the main breakout panel',
+    );
+  }
+
+  async predefinedGroupsWithLongNames() {
+    await this.modPage.waitForSelector(e.whiteboard);
+    await this.userPage.waitForSelector(e.whiteboard);
+
+    await this.modPage.waitAndClick(e.breakoutRoomSidebarButton);
+
+    await this.modPage.hasElement(e.breakoutBox0, 'should display the breakout box for unassigned users');
+
+    await this.modPage.hasElement(e.breakoutBox1, 'should display the breakout box for room 1');
+    await this.modPage.hasElementCount(
+      `${e.breakoutBox1} div[draggable="true"]`,
+      1,
+      'should display only 1 user in the breakout room 1',
+    );
+    await this.modPage.hasText(
+      e.breakoutBox1,
+      LONG_GROUP_NAMES.control,
+      'should seed the short control group name into breakout room 1',
+    );
+    await this.modPage.hasText(
+      e.breakoutBox2,
+      LONG_GROUP_NAMES.chars150,
+      'should seed the 150-character group name into breakout room 2',
+    );
+
+    // the panel renders 2 rooms by default; expand it to display the two boundary groups
+    await this.modPage.waitAndClick(e.increaseRooms);
+    await this.modPage.waitAndClick(e.increaseRooms);
+    await this.modPage.hasText(
+      'div[id="breakoutBox-3"]',
+      LONG_GROUP_NAMES.boundary100,
+      'should seed the 100-character group name into breakout room 3',
+    );
+    await this.modPage.hasText(
+      'div[id="breakoutBox-4"]',
+      LONG_GROUP_NAMES.boundary101,
+      'should seed the 101-character group name into breakout room 4',
     );
   }
 

--- a/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
+++ b/bigbluebutton-tests/playwright/parameters/parameters.spec.ts
@@ -669,6 +669,18 @@ test.describe.parallel('Custom Parameters', { tag: '@ci' }, () => {
     await customParam.predefinedGroups();
   });
 
+  test('Predefined groups with names longer than 100 characters', async ({ browser, context, page }, testInfo) => {
+    linkIssue(25676);
+    const customParam = new CustomParameters(browser, context);
+    await customParam.initModPage(page, { createParameter: `${encodeCustomParams(c.groupsWithLongNames)}`, testInfo });
+    await customParam.initUserPage(context, {
+      fullName: `Attendee-1235`,
+      joinParameter: 'userID=1235',
+      testInfo,
+    });
+    await customParam.predefinedGroupsWithLongNames();
+  });
+
   test.describe.parallel('Audio', () => {
     test('Auto join', { tag: '@media' }, async ({ browser, context, page }, testInfo) => {
       const customParam = new CustomParameters(browser, context);


### PR DESCRIPTION
Closes #25676

### Summary

The `groups` parameter of the create API accepts group names (and ids) of any length, but `meeting_group.groupId` and `meeting_group.name` are `varchar(100)`. A group name longer than 100 characters made the database reject the insert while the create call still returned `SUCCESS`: the meeting came up without any of its pre-assigned groups, the moderator found empty breakout rooms to fill by hand, and the integrator had no error to detect or retry on.

Because all groups of a meeting are written as a single fused transaction, one overflowing name silently dropped **all** groups of that create call, not just the offending one (reproduced live: a create with 3 groups, 1 long, persisted 0 rows).

This PR widens `meeting_group.groupId` and `meeting_group.name` to `text`, so every group sent by the integrator reaches the database and the breakout rooms panel, whatever its length. This follows the direction the project already took in #24486 for the same class of problem, and is consistent with the open sibling #25728.

### Root Cause

- The `groups` parameter was added without any length bound in 2.5 (`e919e24b38`, 2021). In the Meteor era the groups were stored in Mongo without a width, so long names worked.
- The `varchar(100)` width was introduced together with the `meeting_group` table in the GraphQL migration (`52fd6d3ad5`, first released in 3.0.0), with no bound added at the API boundary. Long group names have been silently dropped ever since: a silent regression present in 3.0.x, 3.1 and 4.0.
- `ParamsProcessorUtil.processGroupsParams` reads `id` and `name` without any length check, and `MeetingGroupDAO.insert` writes all groups of the meeting in one `DBIO.sequence(...).transactionally`, so the batched write fails as a whole. The batch error isolation from #25631 discards just that action and logs `value too long for type character varying(100)`, but nothing reaches the caller.
- Identified by reproducing the issue steps live on a 4.0 from-source environment and reading the akka journal.

### Implementation

- `bbb-graphql-server/bbb_schema.sql`: `meeting_group."groupId"` and `meeting_group."name"` change from `varchar(100)` to `text` (2 lines). This is the whole fix:
  - The akka DAO (`MeetingGroupDAO.scala`) uses unbounded `column[String]`, so no Scala change is needed.
  - `v_meeting_group` is a `select *` view and the Hasura permission lists are unchanged, so no metadata change is needed.
  - There is no migrations directory: the schema file is reapplied on deploy (same note as #25728).
  - `meeting_group."meetingId"` stays `varchar(100)` on purpose: it is the FK to `meeting."meetingId"` and matches every other table.
- Alternative considered: rejecting or truncating long names at the API boundary (the "clear validation error" from the issue's expected behavior). Deliberately not included in this PR, keeping the trade-off already made in #24486 and #25728: widening cures the user-facing impact for every length with zero API surface change, while a new validation bound is an API policy decision that would deserve its own discussion. This PR intentionally does not deliver a validation error for oversized values.
- Behavior for invalid JSON in `groups` is untouched (no Java code changes).

### Test Coverage

New e2e test `Predefined groups with names longer than 100 characters` (`@ci`, `linkIssue(25676)`), in `bigbluebutton-tests/playwright/parameters/`:

- **Objective:** guarantee that groups sent through the create API reach the breakout rooms panel regardless of name/id length, in a single create exercising the old failure modes.
- **Scenario:** one create call with 4 groups: a short control group ("Control Group", roster with one user), a 150-character name whose group id is also 150 characters, a 100-character name (old boundary, used to work) and a 101-character name (old boundary, used to fail).
- **Assertions:** breakout boxes are displayed (id-based `div[id="breakoutBox-N"]` selectors); room 1 shows exactly 1 assigned user and the control name; rooms 2-4 show the 150/100/101-character names seeded (panel expanded from the default 2 rooms via the increase button).
- **Red-first evidence:** before the fix the test fails (no group is seeded, rooms show default names and no assignment); after the fix it passes.
- Existing test `Predefined groups for Breakout Rooms` kept green (run in the same session).

Files: `parameters/constants.ts` (new `LONG_GROUP_NAMES` + `groupsWithLongNames` create parameter), `parameters/customparameters.ts` (new `predefinedGroupsWithLongNames()` following the `predefinedGroups()` mold), `parameters/parameters.spec.ts` (new test in the `Custom Parameters` describe).

### Manual Test Cases

| Scenario | Expected | Obtained |
|---|---|---|
| create with short group name (control) | row persisted, group seeded in panel | OK (9-char row present) |
| create with 150-char group name | `SUCCESS` and group persisted/seeded | OK (row with length 150; pre-fix: 0 rows) |
| create with 3 groups, 1 long (mixed) | all 3 groups persisted | OK (3 rows; pre-fix: 0 rows, all-or-nothing) |
| boundary: 100-char and 101-char names | both persisted | OK (rows with length 100 and 101) |
| create with 150-char group id | row persisted | OK (groupId length 150) |
| group without `name` | defaults to empty string (unchanged) | OK (row with length 0) |
| group names in panel UI | long names truncated with ellipsis in the room card, full value in the edit input | OK (visual) |
| akka journal during all runs above | no `value too long`, no batch errors | OK (0 occurrences since deploy) |
| existing Predefined groups e2e | still green | OK (passed) |

### Evidence

- Before the fix: create with the 4-group payload returns `SUCCESS`, `meeting_group` stays empty and the breakout rooms panel shows default "Room 1"/"Room 2" with nobody assigned. https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-09-02/4b9a7b9b-cdc5-4729-86c4-9342a8803a08/modal-pre-fix.mp4 (screenshot: https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-09-02/e0e0d559-3792-4b66-a3cd-ad14543150a1/test-failed-1.png); server log shows `value too long for type character varying(100)`.
- After the fix: same payload seeds all 4 rooms, including the 150-character name, with the roster user assigned to the control room.

Preview below - click the GIF to open the MP4 (better quality, with controls):

[![Breakout rooms panel seeded with long group names](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-09-02/14efbd21-4450-4ac1-ace9-ed9189a1fd30/modal-post-fix.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-09-02/314683c3-4c64-455b-b7c1-0b895ba536ec/modal-post-fix.mp4)

### Risks / Notes

- Primary key on `text` columns is normal in Postgres; the `meeting_group` PK (`meetingId`,`groupId`) is unchanged.
- No validation error is returned for oversized values (deliberate, see Implementation); if the project later wants an API bound for `groups`, that is a separate policy discussion.
- 3.0 is affected by the same defect at the same lines (`bbb_schema.sql`, `groupId`/`name`); #24486 went directly into `v3.0.x-release`, so a backport of this change would be straightforward. Offered here as a note; not opened without a maintainer request.
- The repository's playwright suite has pre-existing prettier/tsc debt in unrelated files; the files touched here pass `prettier --check`, `eslint` and `tsc`.
