### PR TITLE
feat(whiteboard): make ctrl-to-zoom wheel behavior configurable

### DIFF
--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -820,6 +820,7 @@ export interface Whiteboard {
   maxNumberOfActiveUsers: number
   maxHistoryStackSize: number
   slideSwapDecodeTimeoutMs: number
+  wheelZoomRequiresCtrl: boolean
   lockToolbarTools: boolean
   annotations: Annotations
   allowInfiniteWhiteboard: boolean

--- a/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
+++ b/bigbluebutton-html5/imports/ui/components/whiteboard/hooks.js
@@ -225,8 +225,11 @@ const useMouseEvents = ({
     // Get the current camera position and zoom level
     const { x: cx, y: cy, z: cz } = tlEditorRef.current.getCamera();
 
-    // Check if user wants to zoom (Ctrl/Cmd key pressed)
-    if (event.ctrlKey || event.metaKey) {
+    const wheelZoomRequiresCtrl = window.meetingClientSettings.public.whiteboard
+      .wheelZoomRequiresCtrl ?? true;
+
+    // Check if user wants to zoom (Ctrl/Cmd key pressed, or wheel zooms directly)
+    if (!wheelZoomRequiresCtrl || event.ctrlKey || event.metaKey) {
       let currentZoomLevel = cz / initialZoomRef.current;
       if (event.deltaY < 0) {
         currentZoomLevel = Math.min(currentZoomLevel + ZOOM_IN_FACTOR, MAX_ZOOM_FACTOR);

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -868,6 +868,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       maxNumberOfActiveUsers: 25,
       maxHistoryStackSize: 400,
       slideSwapDecodeTimeoutMs: 250,
+      wheelZoomRequiresCtrl: true,
       lockToolbarTools: false,
       allowInfiniteWhiteboard: false,
       allowInfiniteWhiteboardInBreakouts: false,

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1204,6 +1204,10 @@ public:
     # old (un-gated) behavior instead of leaving the un-gated toolbar/zoom UI on a stale
     # slide. Latency above this bound still shows the original white flash.
     slideSwapDecodeTimeoutMs: 250
+    # Presenter mouse wheel behavior over the presentation:
+    # true  - the wheel scrolls (pans) the slide; hold Ctrl/Cmd while scrolling to zoom
+    # false - the wheel zooms directly (behavior of BBB 3.0 and earlier)
+    wheelZoomRequiresCtrl: true
     lockToolbarTools: false
     annotations:
       status:


### PR DESCRIPTION
## What does this PR do?

Makes the 4.0 mouse-wheel behavior on the whiteboard configurable via a new
`public.whiteboard.wheelZoomRequiresCtrl` setting.

- `true` (default): the wheel scrolls (pans) the slide; hold Ctrl/Cmd while
  scrolling to zoom — the current 4.0 behavior from #25527, unchanged.
- `false`: the wheel zooms directly, as in BBB 3.0 and earlier.

## Motivation

#25527 changed the presenter's mouse wheel from zooming to scrolling. Some
deployments' users have relied on zoom-by-wheel navigation for many years and
find it the fastest way to navigate a slide, and portrait slides (where
scrolling pays off) are rare e.g. in school lectures. This keeps the new
behavior as the default while letting such deployments restore the old one
with a one-line override in `/etc/bigbluebutton/bbb-html5.yml`, or per meeting
via `clientSettingsOverride`.

@hiroshisuga asked in https://groups.google.com/g/bigbluebutton-dev/c/4vDKx02hs3E

> I am just wondering if we can make this feature optional:
> feat(whiteboard): mouse wheel scrolls instead of zooming (use ctrl to zoom)
> My users are already used to the zoom-by-wheel behaviour and it has been very comfortable to navigate the slide quickly. This has not been changed for many years in BBB. In addition, in school lectures we rarely use portrait dimension slide. 
> Thank you for the consideration!
 

## More

The flag is read in `handleMouseWheel` with a fallback to `true`, so clients
briefly served a settings payload predating this key during a rolling upgrade
keep the default behavior. Viewer wheel handling and pinch-zoom are untouched.
