### PR TITLE
fix(recording): use instance variable for segment break timestamp

### DIFF
--- a/record-and-playback/core/lib/recordandplayback/workers/base_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/base_worker.rb
@@ -189,7 +189,7 @@ module BigBlueButton
         @full_id = if @break_timestamp.nil?
                      @meeting_id
                    else
-                     "#{@meeting_id}-#{break_timestamp}"
+                     "#{@meeting_id}-#{@break_timestamp}"
                    end
 
         @logger = BigBlueButton.logger


### PR DESCRIPTION
### What does this PR do?
Fixes a `NameError` that crashed recording worker when processing a chapter break segment: 

`@full_id` interpolated `break_timestamp` instead of `@break_timestamp`, so BaseWorker#initialize raised NameError. Only reachable for recording chapter break segments, which are disabled by default.