### PR TITLE
fix(user-list): restore per-user "Lock public chat" action

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/user-list/hooks/useUserOperations.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/hooks/useUserOperations.ts
@@ -11,6 +11,7 @@ import {
   SET_LOCKED,
   SET_PRESENTER,
   SET_RAISE_HAND,
+  SET_USER_CHAT_LOCKED,
 } from '/imports/ui/core/graphql/mutations/userMutations';
 import { useModalRegistration } from '/imports/ui/core/singletons/modalController';
 
@@ -73,6 +74,7 @@ export const useUserOperations = (userId?: string) => {
   const [setPresenter] = useMutation(SET_PRESENTER);
   const [setRole] = useMutation(SET_ROLE);
   const [setLocked] = useMutation(SET_LOCKED);
+  const [setUserChatLocked] = useMutation(SET_USER_CHAT_LOCKED);
   const [userEjectCameras] = useMutation(USER_EJECT_CAMERAS);
   const [ejectFromMeeting] = useMutation(EJECT_FROM_MEETING);
   const [ejectFromVoice] = useMutation(EJECT_FROM_VOICE);
@@ -94,6 +96,7 @@ export const useUserOperations = (userId?: string) => {
       setPresenter,
       setRole,
       setLocked,
+      setUserChatLocked,
       userEjectCameras,
       setRaiseHand,
       removeUser,

--- a/bigbluebutton-html5/imports/ui/components/user-list/raised-hands/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/raised-hands/list-item/component.tsx
@@ -202,6 +202,7 @@ const RaisedHandsListItem: React.FC<RaisedHandsListItemProps> = ({
     operations.userEjectCameras,
     () => modal.setIsOpen(true),
     operations.setRaiseHand,
+    operations.setUserChatLocked,
   );
 
   const Settings = getSettingsSingletonInstance();

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/component.tsx
@@ -135,6 +135,7 @@ const UserListItem: React.FC<UserListItemProps> = ({
     operations.userEjectCameras,
     () => modal.setIsOpen(true),
     operations.setRaiseHand,
+    operations.setUserChatLocked,
   );
 
   const userAvatarFiltered = (user.away === true || (user.reactionEmoji && user.reactionEmoji !== 'none')) ? '' : user.avatar;

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/service.ts
@@ -223,6 +223,14 @@ export const generateActionsPermissions = (
     && lockSettings?.hasActiveLockSetting
     && (type === 'participant' || type === 'raised-hand');
 
+  // Per-user public chat lock (as in 3.0): independent of the meeting-wide lock settings
+  const allowedToLockPublicChat = isChatEnabled
+    && amIModerator
+    && !isSubjectUserModerator
+    && !isDialInUser
+    && !isSubjectUserBot
+    && type === 'participant';
+
   const allowedToEjectCameras = amIModerator
     && !amISubjectUser
     && usersPolicies?.allowModsToEjectCameras
@@ -243,6 +251,7 @@ export const generateActionsPermissions = (
     allowedToPromote,
     allowedToDemote,
     allowedToChangeUserLockStatus,
+    allowedToLockPublicChat,
     allowedToEjectCameras,
     allowedToRemove,
     allowedToLowerHand,
@@ -338,6 +347,7 @@ export const createToolbarOptions = (
   userEjectCameras: MutationFunction,
   openConfirmationModal: () => void,
   setRaiseHand: MutationFunction,
+  setUserChatLocked: MutationFunction,
 ) => {
   const MODERATOR_ROLE = window.meetingClientSettings.public.user.role_moderator;
   const VIEWER_ROLE = window.meetingClientSettings.public.user.role_viewer;
@@ -350,6 +360,7 @@ export const createToolbarOptions = (
     allowedToPromote,
     allowedToDemote,
     allowedToChangeUserLockStatus,
+    allowedToLockPublicChat,
     allowedToEjectCameras,
     allowedToRemove,
     allowedToLowerHand,
@@ -359,6 +370,7 @@ export const createToolbarOptions = (
   const userLocked = user.locked
     && lockSettings?.hasActiveLockSetting
     && !user.isModerator;
+  const userChatLocked = !!user.userLockSettings?.disablePublicChat;
 
   const getAudioStateOption = () => {
     if (!subjectUserInAudio) return null;
@@ -513,6 +525,23 @@ export const createToolbarOptions = (
         },
         icon: userLocked ? 'unlock' : 'lock',
         dataTest: 'unlockUserButton',
+      },
+      {
+        allowed: allowedToLockPublicChat,
+        key: 'lockChat',
+        label: userChatLocked
+          ? intl.formatMessage(intlMessages.unlockPublicChat)
+          : intl.formatMessage(intlMessages.lockPublicChat),
+        onClick: () => {
+          setUserChatLocked({
+            variables: {
+              userId: user.userId,
+              disablePubChat: !userChatLocked,
+            },
+          });
+        },
+        icon: userChatLocked ? 'unlock' : 'lock',
+        dataTest: 'togglePublicChat',
       },
       {
         allowed: allowedToEjectCameras,

--- a/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/types.ts
+++ b/bigbluebutton-html5/imports/ui/components/user-list/user-list-participants/list-item/types.ts
@@ -40,6 +40,7 @@ export interface UserActionPermissions {
   allowedToPromote: boolean | undefined;
   allowedToDemote: boolean | undefined;
   allowedToChangeUserLockStatus: boolean | undefined;
+  allowedToLockPublicChat: boolean | undefined;
   allowedToEjectCameras: boolean | undefined;
   allowedToRemove: boolean | undefined;
   allowedToLowerHand: boolean | undefined;

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -556,6 +556,7 @@ export const elements = {
   // Lock Viewers
   lockViewersButton: 'button[data-test="lockViewersButton"]',
   unlockUserButton: 'li[data-test="unlockUserButton"]',
+  togglePublicChat: 'li[data-test="togglePublicChat"]',
   applyLockSettings: 'button[data-test="applyLockSettings"]',
   guestPolicyTab: '[data-test="guestPolicyTab"]',
   guestPolicySelector: '[data-test="guestPolicySelector"]',

--- a/bigbluebutton-tests/playwright/user/lockViewers.ts
+++ b/bigbluebutton-tests/playwright/user/lockViewers.ts
@@ -126,6 +126,34 @@ export class LockViewers extends MultiUsers {
     await this.userPage2.hasElement(e.isTalking, 'should display the is talking element for the second attendee');
   }
 
+  async lockPublicChatForSpecificUser() {
+    // no meeting-wide lock is active: the per-user action must be available anyway
+    const attendeeRow = this.modPage.page.locator(e.userListItem).filter({ hasText: this.userPage.username });
+    const isAttendeeRowVisible = await attendeeRow.isVisible({ timeout: ELEMENT_WAIT_TIME }).catch(() => false);
+    if (!isAttendeeRowVisible) {
+      await this.modPage.waitAndClick(e.usersListSidebarButton);
+    }
+    await attendeeRow.locator(e.moreOptionsUserItemButton).click();
+    await this.modPage.page.locator(`${e.togglePublicChat}:visible`).first().click();
+    await this.userPage.hasElementDisabled(e.chatBox, 'should have the public chat disabled for the locked attendee');
+    await this.userPage.hasElementDisabled(
+      e.sendButton,
+      'should have the send button on the public chat disabled for the locked attendee',
+    );
+    await expect(attendeeRow, 'should display the locked label on the attendee row for the moderator').toContainText(
+      /locked/i,
+    );
+    // unlock the same user
+    await attendeeRow.locator(e.moreOptionsUserItemButton).click();
+    await this.modPage.page.locator(`${e.togglePublicChat}:visible`).first().click();
+    await this.userPage.hasElementEnabled(
+      e.chatBox,
+      'should have the public chat enabled again for the unlocked attendee',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+    await expect(attendeeRow, 'should remove the locked label from the attendee row').not.toContainText(/locked/i);
+  }
+
   async lockSendPublicChatMessages() {
     // mod send a message
     await this.modPage.fill(e.chatBox, e.message);

--- a/bigbluebutton-tests/playwright/user/user.spec.ts
+++ b/bigbluebutton-tests/playwright/user/user.spec.ts
@@ -69,6 +69,12 @@ test.describe.parallel('User', { tag: '@ci' }, () => {
       await lockViewers.lockedViewerCanSendPrivateMessageToModerator();
     });
 
+    test('Lock public chat for a specific user', async ({ browser, context, page }, testInfo) => {
+      const lockViewers = new LockViewers(browser, context);
+      await lockViewers.initPages(page, testInfo);
+      await lockViewers.lockPublicChatForSpecificUser();
+    });
+
     test('Toggle user list', async ({ browser, context, page }, testInfo) => {
       const multiusers = new MultiUsers(browser, context);
       await multiusers.initModPage(page, { testInfo });

--- a/docs/docs/testing/release-testing.md
+++ b/docs/docs/testing/release-testing.md
@@ -1111,6 +1111,20 @@ Enable Microphone : This will cause a user name to appear on left top corner of 
 
 19. All users should be able to send public chat messages now.
 
+### Public chat for a specific user [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v4.0.x-release/bigbluebutton-tests/playwright/user/user.spec.ts)
+
+1. Join meeting with a moderator and a viewer. Do not enable any "Lock viewers" setting.
+
+2. Moderator: open the viewer's actions menu in the user list and select "Lock public chat".
+
+3. Viewer: should see the public chat textbox and send button disabled, while other viewers keep sending public chat messages.
+
+4. Moderator: the viewer's row in the user list should show the "Locked" label. The moderator should still be able to send public chat messages.
+
+5. Moderator: open the same viewer's actions menu and select "Unlock public chat".
+
+6. Viewer: should be able to send public chat messages again and the "Locked" label should disappear.
+
 ### Private chat [(Automated)](https://github.com/bigbluebutton/bigbluebutton/blob/v3.0.x-release/bigbluebutton-tests/playwright/presentation/presentation.spec.js)
 
 1. Join meeting with moderators and viewers.


### PR DESCRIPTION
The 4.0 user-list rewrite (c15af691e1d, #22004) replaced the old user-actions menu with list-item/service.ts and dropped the `lockChat` entry. Everything behind it survived: the `userSetUserLockSettings` Hasura action, the graphql-actions handler, `ChangeUserLockSettingsInMeetingCmdMsg` in akka-apps, the user_lockSettings table, the SET_USER_CHAT_LOCKED client mutation, the intl strings and the "Locked" badge. Only the menu item that called it was gone, so moderators lost the ability to silence a single spamming viewer without locking public chat for everyone.

Wire the existing mutation back into the participants list item:

- expose `setUserChatLocked` from useUserOperations
- add `allowedToLockPublicChat` with the 3.0 gate (chat enabled, moderator acting on a non-moderator, not dial-in or bot), which does not require a meeting-wide lock setting to be active
- add the `lockChat` toolbar option toggling `userLockSettings.disablePublicChat`, data-test `togglePublicChat`

Add a Playwright regression test (moderator locks and unlocks one viewer's public chat, viewer input disables/enables, row shows the locked label) and the matching release-testing catalog entry.

Closes #25738