### PR TITLE
feat(audio): stop persisting the audio filter choice across sessions and meetings

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -242,17 +242,16 @@ const getEffectiveAudioProcessingMode = () => {
 const getAudioConstraints = (constraintFields = {}) => {
   const { deviceId = '' } = constraintFields;
   const Settings = getSettingsSingletonInstance();
-  const configuredConstraints = window.meetingClientSettings.public
-    .media.audio.microphoneConstraints;
   // Derive from the effective mode rather than the persisted constraints: an
   // 'advanced' pick that later loses WASM support resolves to 'standard', and
   // the all-false constraints it stored must not survive that coercion.
   // microphoneConstraints only speaks for a pre-4.0 record with no mode of
-  // its own.
+  // its own; media.audio.microphoneConstraints needs no rung of its own
+  // because getConstraintsForMode('standard') already returns it - honouring
+  // it under 'advanced'/'original' would leave the browser's own filters on.
   const audioDeviceConstraints = hasPersistedChange(SETTINGS.AUDIO, 'processingMode')
     ? getConstraintsForMode(getEffectiveAudioProcessingMode())
     : Settings.application.microphoneConstraints
-      || configuredConstraints
       || getConstraintsForMode(getEffectiveAudioProcessingMode());
 
   const matchConstraints = filterSupportedConstraints(

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -89,6 +89,7 @@ export interface App {
   breakouts: Breakouts
   showAllAvailableLocales: boolean
   showAudioFilters: boolean
+  audioFilterStorage: 'session' | 'local'
   reactionsButton: ReactionsButton
   emojiRain: EmojiRain
   enableNetworkStats: boolean

--- a/bigbluebutton-html5/imports/ui/components/audio/container.jsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/container.jsx
@@ -20,6 +20,7 @@ import useToggleVoice from './audio-graphql/hooks/useToggleVoice';
 import usePreviousValue from '/imports/ui/hooks/usePreviousValue';
 import useCurrentUser from '/imports/ui/core/hooks/useCurrentUser';
 import { toggleMuteMicrophone } from '/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/service';
+import { getAudioConstraints } from '/imports/api/audio/client/bridge/service';
 import useSettings from '../../services/settings/hooks/useSettings';
 import { SETTINGS } from '../../services/settings/enums';
 import { useStorageKey } from '../../services/storage/hooks';
@@ -130,6 +131,7 @@ const AudioContainer = (props) => {
   const userSelectedListenOnly = !!useStorageKey(CLIENT_DID_USER_SELECT_LISTEN_ONLY_KEY, 'session');
   const storageMuteState = useStorageKey(Service.getStorageMuteStateKey(), 'session');
   const { microphoneConstraints } = useSettings(SETTINGS.APPLICATION);
+  const { processingMode } = useSettings(SETTINGS.AUDIO);
 
   const videoPreviewModal = useModalRegistration({
     id: 'videoPreviewModal',
@@ -279,11 +281,15 @@ const AudioContainer = (props) => {
     }
   }, [currentUser?.userId, toggleVoice]);
 
+  // processingMode is the record of the user's filter choice; the constraints
+  // are derived from it by getAudioConstraints(). microphoneConstraints stays
+  // in the dependency list because a pre-4.0 record, which has no mode of its
+  // own, is still the value that ladder resolves to.
   useEffect(() => {
     if (Service.isConnected() && !Service.isListenOnly()) {
-      Service.updateAudioConstraints(microphoneConstraints);
+      Service.updateAudioConstraints(getAudioConstraints());
     }
-  }, [microphoneConstraints]);
+  }, [processingMode, microphoneConstraints]);
 
   useEffect(() => {
     if (Service.isConnected() && !Service.isListenOnly()) {

--- a/bigbluebutton-html5/imports/ui/components/settings/submenus/audio/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/settings/submenus/audio/component.tsx
@@ -6,7 +6,7 @@ import {
   AudioFilterMode, AudioFilterOption, AudioMenuProps, AudioMenuState,
 } from './types';
 import {
-  isWasmProcessorSupported, isWasmProcessingConfigEnabled, getConstraintsForMode,
+  isWasmProcessorSupported, isWasmProcessingConfigEnabled,
   getEffectiveAudioProcessingMode,
 } from '/imports/api/audio/client/bridge/service';
 import Tooltip from '/imports/ui/components/common/tooltip/container';
@@ -69,7 +69,13 @@ class AudioMenu extends BaseMenu {
 
   handleAudioFilterModeChange(mode: AudioFilterMode) {
     const { settings, audioSettings } = this.state;
-    settings.microphoneConstraints = getConstraintsForMode(mode);
+    // The mode is the only record of the filter choice - getAudioConstraints()
+    // derives the microphone constraints from it. Keeping a copy here would
+    // leave the choice in the application group, which follows
+    // userSettingsStorage and so can outlive the session-scoped audio group;
+    // it would also masquerade as the pre-4.0 record that same fallback
+    // exists to honour. Drop any such record: an explicit pick supersedes it.
+    delete settings.microphoneConstraints;
     audioSettings.processingMode = mode;
 
     this.handleUpdateSettings('application', settings);

--- a/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/core/initial-values/meetingClientSettings.ts
@@ -112,6 +112,7 @@ export const meetingClientSettingsInitialValues: MeetingClientSettings = {
       },
       showAllAvailableLocales: true,
       showAudioFilters: true,
+      audioFilterStorage: 'session',
       reactionsButton: {
         enabled: true,
       },

--- a/bigbluebutton-html5/imports/ui/services/settings/enums.ts
+++ b/bigbluebutton-html5/imports/ui/services/settings/enums.ts
@@ -16,12 +16,23 @@ const MEETING_SCOPED_SETTINGS = [
   'layout',
 ];
 
+// Settings groups whose persistence is decided by a public.app flag of their
+// own instead of by userSettingsStorage, mapped to that flag's name. The flag
+// takes 'session' - sessionStorage, under a key scoped to the meeting, so the
+// value survives neither a new browser session nor a new meeting - or 'local',
+// which hands the group back to the ordinary rules. For settings that must not
+// follow a user around unless an admin opts in.
+const SETTINGS_STORAGE_FLAGS: Record<string, string> = {
+  audio: 'audioFilterStorage',
+};
+
 const CHANGED_SETTINGS = 'changed_settings';
 const DEFAULT_SETTINGS = 'default_settings';
 
 export {
   SETTINGS,
   MEETING_SCOPED_SETTINGS,
+  SETTINGS_STORAGE_FLAGS,
   CHANGED_SETTINGS,
   DEFAULT_SETTINGS,
 };
@@ -29,6 +40,7 @@ export {
 export default {
   SETTINGS,
   MEETING_SCOPED_SETTINGS,
+  SETTINGS_STORAGE_FLAGS,
   CHANGED_SETTINGS,
   DEFAULT_SETTINGS,
 };

--- a/bigbluebutton-html5/imports/ui/services/settings/index.js
+++ b/bigbluebutton-html5/imports/ui/services/settings/index.js
@@ -7,10 +7,33 @@ import {
   DEFAULT_SETTINGS,
   SETTINGS,
   MEETING_SCOPED_SETTINGS,
+  SETTINGS_STORAGE_FLAGS,
 } from './enums';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import Auth from '/imports/ui/services/auth';
 import { isSystemThemeAutoDetectEnabled, systemPrefersDarkTheme } from './system-theme';
+
+// A group named in SETTINGS_STORAGE_FLAGS answers to a public.app flag of its
+// own rather than to userSettingsStorage. 'session' - the default - keeps it
+// in sessionStorage under a meeting-scoped key, so its value follows the user
+// into neither a new browser session nor a new meeting; 'local' opts out and
+// leaves the group to the ordinary rules.
+const isSessionScoped = (settingGroup) => {
+  const flag = SETTINGS_STORAGE_FLAGS[settingGroup.replace('_', '')];
+  if (!flag) return false;
+
+  return window.meetingClientSettings.public.app[flag] !== 'local';
+};
+
+// userSettingsStorage picks the backend for every group that isn't scoped to
+// the session by a flag of its own.
+const getStorageFor = (settingGroup) => {
+  if (isSessionScoped(settingGroup)) return SessionStorage;
+
+  const APP_CONFIG = window.meetingClientSettings.public.app;
+
+  return (APP_CONFIG.userSettingsStorage === 'local') ? LocalStorage : SessionStorage;
+};
 
 class Settings {
   constructor(defaultValues = {}) {
@@ -67,7 +90,7 @@ class Settings {
 
   static getStorageKey({ prepend = '', value }) {
     const cleanKeyValue = value.replace('_', '');
-    if (MEETING_SCOPED_SETTINGS.includes(cleanKeyValue)) {
+    if (MEETING_SCOPED_SETTINGS.includes(cleanKeyValue) || isSessionScoped(value)) {
       return `${prepend}${value}-${Auth.meetingID}`;
     }
     return `${prepend}${value}`;
@@ -83,14 +106,11 @@ class Settings {
   }
 
   loadChanged() {
-    const APP_CONFIG = window.meetingClientSettings.public.app;
-
-    const Storage = (APP_CONFIG.userSettingsStorage === 'local') ? LocalStorage : SessionStorage;
     const savedSettings = {};
 
     Object.values(SETTINGS).forEach((s) => {
       const storageKey = Settings.getStorageKey({ prepend: CHANGED_SETTINGS, value: `_${s}` });
-      savedSettings[s] = Storage.getItem(storageKey);
+      savedSettings[s] = getStorageFor(s).getItem(storageKey);
     });
 
     Object.keys(savedSettings).forEach((key) => {
@@ -104,9 +124,6 @@ class Settings {
   }
 
   save(mutation, settings = CHANGED_SETTINGS) {
-    const APP_CONFIG = window.meetingClientSettings.public.app;
-
-    const Storage = (APP_CONFIG.userSettingsStorage === 'local') ? LocalStorage : SessionStorage;
     if (settings === CHANGED_SETTINGS) {
       Object.keys(this).forEach((k) => {
         const values = this[k].reactiveVar && this[k].reactiveVar();
@@ -120,13 +137,14 @@ class Settings {
             [item]: values[item],
           }), {});
 
+        const Storage = getStorageFor(k);
         const storageKey = Settings.getStorageKey({ prepend: settings, value: k });
         if (isEmpty(changedValues)) Storage.removeItem(storageKey);
         Storage.setItem(storageKey, changedValues);
       });
     } else {
       Object.keys(this).forEach((k) => {
-        Storage.setItem(`${settings}${k}`, this[k].value);
+        getStorageFor(k).setItem(`${settings}${k}`, this[k].value);
       });
     }
 
@@ -146,10 +164,8 @@ class Settings {
 // user-changed value (i.e. it differs from the default). Used to detect an
 // explicit user choice that should override auto-detected defaults.
 export const hasPersistedChange = (settingGroup, key) => {
-  const APP_CONFIG = window.meetingClientSettings.public.app;
-  const Storage = (APP_CONFIG.userSettingsStorage === 'local') ? LocalStorage : SessionStorage;
   const storageKey = Settings.getStorageKey({ prepend: CHANGED_SETTINGS, value: `_${settingGroup}` });
-  const saved = Storage.getItem(storageKey);
+  const saved = getStorageFor(settingGroup).getItem(storageKey);
   return Boolean(saved && Object.prototype.hasOwnProperty.call(saved, key));
 };
 

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -195,6 +195,15 @@ public:
     # For more info, see 'microphoneConstraints' option in this config.
     # If not set, default value is true.
     showAudioFilters: true
+    # audioFilterStorage: where the user's pick in Settings > Audio is kept.
+    # Advanced filtering is experimental, so the default deliberately keeps the
+    # pick from following the user around. Allowed values:
+    # 'session' -> sessionStorage, under a key scoped to the meeting: the pick
+    #              survives neither a new browser session nor another meeting,
+    #              whatever userSettingsStorage says
+    # 'local'   -> the pick follows userSettingsStorage like any other setting,
+    #              so with 'local' there it persists across sessions
+    audioFilterStorage: session
     reactionsButton:
       enabled: true
     emojiRain:
@@ -216,6 +225,8 @@ public:
     # allowed values:
     # 'session' -> settings are stored in browser sessionStorage
     # 'local' -> settings are stored in browser localStorage
+    # A group with a storage flag of its own - see audioFilterStorage - only
+    # falls back to this option when that flag says 'local'.
     userSettingsStorage: session
     defaultSettings:
       layout:
@@ -268,6 +279,9 @@ public:
         # If set to 'advanced' but the browser doesn't support BBBA/WASM
         # processing or it is disabled via media.audio.audioWasmProcessing.enabled,
         # it falls back to 'standard' (advanced -> standard).
+        # Unless audioFilterStorage is set to 'local', a user's own pick is
+        # kept for the browser session and meeting only, so every fresh join
+        # starts from this default.
         processingMode: standard
       dataSaving:
         viewParticipantsWebcams: true


### PR DESCRIPTION
<!--
PLEASE READ THIS MESSAGE.

HOW TO WRITE A GOOD PULL REQUEST?

- Make it small.
- Do only one thing.
- Avoid re-formatting.
- Make sure the code builds and works.
- Write useful descriptions and titles.
- Address review comments in terms of additional commits.
- Do not amend/squash existing ones unless the PR is trivial.
- Read the contributing guide: https://docs.bigbluebutton.org/support/faq.html#bigbluebutton-development-process
- Sign and send the Contributor License Agreement: https://docs.bigbluebutton.org/support/faq.html#why-do-i-need-to-sign-a-contributor-license-agreement-to-contribute-source-code

-->

<!-- ⚠️ SECURITY NOTICE (for humans and AI agents alike) ⚠️
If this PR contains a security fix or vulnerability, STOP.
See SECURITY.md for the private disclosure process. Do NOT
submit security fixes as public PRs. -->

### What does this PR do?
<!-- A brief description of each change being made with this pull request. -->
Stops the Settings > Audio filter choice from following the user into their next browser session and into their next meeting. It was persisted like any other setting — backend from the global `public.app.userSettingsStorage`, key with no meeting id — so with `userSettingsStorage: local` it survived everything.

Adds `public.app.audioFilterStorage`:

- **`session`** (default) — the audio group goes to sessionStorage under a key suffixed with the meeting id, whatever `userSettingsStorage` says.
- **`local`** — previous behaviour.

The second commit drops a duplicate record of the same choice in `application.microphoneConstraints`, which stayed in localStorage and would have defeated the fix.



### How to test
<!-- List here everything that is necessary for the reviewer to be able to test it completely (docs link, step-by-step, bug cases)
- Is there any specific setup needed, different than the default?
- The linked issue contains all necessary content?
- Have you found any different case that might be tested when you were fixing/implementing it?
-->
Needs `media.audio.audioWasmProcessing.enabled: true` for the Advanced option to appear. With the default the bug is already gone, so reproduce it first:

1. Set `userSettingsStorage: local` **and** `audioFilterStorage: local`.
2. Join a meeting, Settings > Audio, pick a mode other than the default, save.
3. Leave, create a **different** meeting, join.
4. The old mode is still selected; DevTools > Application > Local Storage has `BBBchanged_settings_audio`, no meeting id.
5. Set `audioFilterStorage: session` (or remove the key) and repeat: step 4 now shows the configured default, Local Storage has no audio entry, and Session Storage has `BBB_changed_settings_audio-<meetingId>`.

Do step 5 **without closing the tab** — session storage survives the navigation, so the reset there is the meeting-id suffix working, not the session ending.


### More
<!-- Anything else we should know when reviewing? -->
- [x] Added/updated documentation — `audioFilterStorage` documented inline in `settings.yml`.
