### PR TITLE
chore(audio): log WASM processor usage in audio lifecycle events

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/audio/audio-processor/service.js
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-processor/service.js
@@ -83,6 +83,7 @@ export {
   adoptWasmProcessor,
   createWasmProcessorStream,
   destroyWasmProcessor,
+  getActiveProviderId,
   getProviderForcedMicrophoneConstraints,
   isWasmProcessorSupported,
   loadWasmProcessorFiles,

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -30,6 +30,7 @@ import {
   setUserSelectedMicrophone,
   setUserSelectedListenOnly,
 } from '/imports/ui/components/audio/service';
+import { getActiveProviderId } from '/imports/ui/components/audio/audio-processor/service';
 
 const CALL_STATES = {
   STARTED: 'started',
@@ -791,6 +792,8 @@ class AudioManager {
             isListenOnly: this.isListenOnly,
             stats: getRTCStatsLogMetadata(stats),
             clientSessionNumber: this.bridge.clientSessionNumber,
+            wasmProcessingEnabled: isWasmProcessingEnabled(),
+            wasmProcessingProvider: getActiveProviderId(),
           },
         }, 'Audio Joined');
       });
@@ -879,6 +882,8 @@ class AudioManager {
             outputDeviceId: this.outputDeviceId,
             outputDevices: this.outputDevicesJSON,
             isListenOnly: this.isListenOnly,
+            wasmProcessingEnabled: isWasmProcessingEnabled(),
+            wasmProcessingProvider: getActiveProviderId(),
           },
         }, 'Audio ended without issue');
       } else if (status === FAILED) {
@@ -1393,6 +1398,21 @@ class AudioManager {
 
     await this.bridge.updateAudioConstraints(constraints);
     this.inputStream = this.bridge ? this.bridge.inputStream : this.inputStream;
+
+    logger.info({
+      logCode: 'audio_constraints_updated',
+      extraInfo: {
+        bridge: this.bridgeName,
+        inputDeviceId: this.inputDeviceId,
+        inputDevices: this.inputDevicesJSON,
+        outputDeviceId: this.outputDeviceId,
+        outputDevices: this.outputDevicesJSON,
+        clientSessionNumber: this.bridge.clientSessionNumber,
+        streamData: MediaStreamUtils.getMediaStreamLogData(this.inputStream),
+        wasmProcessingEnabled: isWasmProcessingEnabled(),
+        wasmProcessingProvider: getActiveProviderId(),
+      },
+    });
 
     // Bridges may re-acquire the stream when doing this. Cleanup is in order if
     // applicable (i.e.: old one is stale, compare via id).


### PR DESCRIPTION
### What does this PR do?
WASM processor usage (enabled state and provider) has no visibility in audio_joined, audio_ended, and audio constraint update logs, making it hard to correlate audio issues with WASM processing in LK's audio bridge from logs alone.

Add wasmProcessingEnabled and wasmProcessingProvider fields to the audio_joined and "Audio ended" log payloads, and introduce a new audio_constraints_updated log entry emitted on device/constraint switches with the same WASM fields plus existing bridge/device/stream context. Export getActiveProviderId from the audio-processor service so audio-manager can resolve the active provider for these payloads.

### Closes Issue(s)
Closes -