### PR TITLE
docs: Document plugin SDK version compatibility

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -178,6 +178,31 @@ In the future, support for additional placeholders may be added.
 
 ### Manifest Json
 
+#### SDK version compatibility
+
+The `requiredSdkVersion` field declares which versions of the
+`bigbluebutton-html-plugin-sdk` a plugin can run against. Keep this range aligned
+with the SDK version used to build the plugin in its `package.json`.
+
+When a meeting starts, BigBlueButton reads its SDK version from the
+`html5PluginSdkVersion` server property and checks whether that version satisfies
+the manifest range. A plugin with an incompatible range is not loaded, and the
+reason is exposed as a plugin load failure from `bbb-apps-akka`.
+
+The field accepts a [semantic version range](https://semver.org/). The two ranges
+used by official plugins have different behavior before version 1.0:
+
+- A tilde range allows patch updates within the specified minor version. For
+  example, `~0.0.77` accepts `0.0.77` and `0.0.78`, but rejects `0.1.0`.
+- A caret range allows updates that do not change the left-most non-zero version.
+  For example, `^0.1.26` accepts `0.1.26` and `0.1.27`, but rejects `0.2.0`.
+  On the `0.0.x` line, `^0.0.77` accepts only `0.0.77`.
+
+Official plugins on the legacy `0.0.x` line therefore use tilde ranges, as shown
+in the examples below. Plugins on the `0.1.x` line use caret ranges. This caret
+convention continues to express compatibility when the SDK reaches `1.x`: for
+example, `^1.0.0` accepts compatible `1.x` releases and rejects `2.0.0`.
+
 Here is a complete `manifest.json` example with all possible configurations:
 
 ```json

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -180,14 +180,17 @@ In the future, support for additional placeholders may be added.
 
 #### SDK version compatibility
 
-The `requiredSdkVersion` field declares which versions of the
-`bigbluebutton-html-plugin-sdk` a plugin can run against. Keep this range aligned
-with the SDK version used to build the plugin in its `package.json`.
+The `requiredSdkVersion` field declares the SDK range supported by the plugin,
+starting with the first SDK version on which it works. This minimum compatible
+version is separate from the SDK dependency used to build the plugin in its
+`package.json`, which may be newer.
 
 When a meeting starts, BigBlueButton reads its SDK version from the
 `html5PluginSdkVersion` server property and checks whether that version satisfies
-the manifest range. A plugin with an incompatible range is not loaded, and the
-reason is exposed as a plugin load failure from `bbb-apps-akka`.
+the manifest range declared by the plugin. The plugin author is responsible for
+choosing the range that determines which BigBlueButton versions can load it. If
+the server SDK does not satisfy that range, BigBlueButton records a plugin load
+failure in `bbb-apps-akka`.
 
 The field accepts a [semantic version range](https://semver.org/). The two ranges
 used by official plugins have different behavior before version 1.0:


### PR DESCRIPTION
## What changed

Added an SDK compatibility section to the plugin manifest documentation explaining:

- what `requiredSdkVersion` declares;
- how BigBlueButton obtains and validates its SDK version;
- how incompatible plugins are reported;
- how tilde and caret ranges behave before version 1.0;
- why legacy `0.0.x` examples use tilde ranges while `0.1.x` plugins use caret ranges;
- why the manifest range should remain aligned with the SDK build dependency.

The existing `0.0.x` manifest examples remain unchanged and are identified as legacy examples.

## Validation

- `npm ci`
- `npm run build`
- Confirmed the section is generated on the plugins documentation page
- Confirmed the documented behavior matches the server implementation

