### PR TITLE
Fix(html5): Move and add button are still shown if cursor is outside of the shared notes

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -406,8 +406,8 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   // Related upstream issues: https://github.com/TypeCellOS/BlockNote/issues/1016 and
   // https://github.com/TypeCellOS/BlockNote/issues/351.
   React.useEffect(() => {
-    const mousemoveHandler = (event: MouseEvent) => {
-      if (!wrapperRef.current?.contains(event.target as Node)) {
+    const mousemoveHandler = (e: MouseEvent) => {
+      if (!wrapperRef.current?.contains(e.target as Node)) {
         editor.getExtension(SideMenuExtension)?.hideMenuIfNotFrozen();
       }
     };
@@ -486,10 +486,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
              Let the controls keep their natural height when BBB typography changes
              the corresponding block height (https://github.com/TypeCellOS/BlockNote/issues/2224). */
           .bn-side-menu,
-          .bn-side-menu[data-block-type="heading"][data-level],
-          .bn-side-menu[data-block-type="file"],
-          .bn-side-menu[data-block-type="audio"],
-          .bn-side-menu[data-url="false"] {
+          .bn-side-menu[data-block-type="heading"][data-level] {
             height: auto;
           }
           /* Flip labels to below when near top of scroll container */

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -482,13 +482,10 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             min-height: 0;
             overflow-y: auto;
           }
-          /* BlockNote hardcodes side-menu heights for its default typography.
-             Let the controls keep their natural height when BBB typography changes
-             the corresponding block height (https://github.com/TypeCellOS/BlockNote/issues/2224). */
-          .bn-side-menu,
-          .bn-side-menu[data-block-type="heading"][data-level] {
-            height: auto;
-          }
+          /* BlockNote 0.53 centers the side menu with floating-ui offsets that
+             assume its default 30px height, so overriding the height would
+             misalign heading drag handles. Historical context:
+             https://github.com/TypeCellOS/BlockNote/issues/2224. */
           /* Flip labels to below when near top of scroll container */
           .bn-block-group > .bn-block-outer:first-child
             .bn-collaboration-cursor__label {

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -485,7 +485,8 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
           /* BlockNote hardcodes side-menu heights for its default typography.
              Let the controls keep their natural height when BBB typography changes
              the corresponding block height (https://github.com/TypeCellOS/BlockNote/issues/2224). */
-          .bn-side-menu[data-block-type="heading"],
+          .bn-side-menu,
+          .bn-side-menu[data-block-type="heading"][data-level],
           .bn-side-menu[data-block-type="file"],
           .bn-side-menu[data-block-type="audio"],
           .bn-side-menu[data-url="false"] {

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { BlockNoteView } from '@blocknote/mantine';
 import * as BlockNoteLocales from '@blocknote/core/locales';
 import { BlockNoteSchema, defaultBlockSpecs } from '@blocknote/core';
+import { SideMenuExtension } from '@blocknote/core/extensions';
 import '@blocknote/core/fonts/inter.css';
 import '@blocknote/mantine/style.css';
 import { HocuspocusProvider } from '@hocuspocus/provider';
@@ -372,6 +373,7 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
   // Keep the editor's focus/selection when tapping a toolbar button by
   // cancelling the default focus move on mousedown.
   const toolbarRef = React.useRef<HTMLDivElement>(null);
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
     const el = toolbarRef.current;
     if (!el) return undefined;
@@ -400,8 +402,21 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
     };
   }, [editor]);
 
+  // TODO: Remove this workaround when BlockNote limits side-menu detection to the editor.
+  // Related upstream issues: https://github.com/TypeCellOS/BlockNote/issues/1016 and
+  // https://github.com/TypeCellOS/BlockNote/issues/351.
+  React.useEffect(() => {
+    const mousemoveHandler = (event: MouseEvent) => {
+      if (!wrapperRef.current?.contains(event.target as Node)) {
+        editor.getExtension(SideMenuExtension)?.hideMenuIfNotFrozen();
+      }
+    };
+    document.addEventListener('mousemove', mousemoveHandler);
+    return () => document.removeEventListener('mousemove', mousemoveHandler);
+  }, [editor]);
+
   return (
-    <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+    <div ref={wrapperRef} style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       <style>
         {`
           .bn-toolbar-row .mantine-Button-label {
@@ -466,6 +481,15 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             flex: 1 1 0;
             min-height: 0;
             overflow-y: auto;
+          }
+          /* BlockNote hardcodes side-menu heights for its default typography.
+             Let the controls keep their natural height when BBB typography changes
+             the corresponding block height (https://github.com/TypeCellOS/BlockNote/issues/2224). */
+          .bn-side-menu[data-block-type="heading"],
+          .bn-side-menu[data-block-type="file"],
+          .bn-side-menu[data-block-type="audio"],
+          .bn-side-menu[data-url="false"] {
+            height: auto;
           }
           /* Flip labels to below when near top of scroll container */
           .bn-block-group > .bn-block-outer:first-child

--- a/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/bn-shared-notes/component.tsx
@@ -482,10 +482,6 @@ function BlockNoteApp(props: BlockNoteAppProps): React.ReactElement {
             min-height: 0;
             overflow-y: auto;
           }
-          /* BlockNote 0.53 centers the side menu with floating-ui offsets that
-             assume its default 30px height, so overriding the height would
-             misalign heading drag handles. Historical context:
-             https://github.com/TypeCellOS/BlockNote/issues/2224. */
           /* Flip labels to below when near top of scroll container */
           .bn-block-group > .bn-block-outer:first-child
             .bn-collaboration-cursor__label {

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -265,6 +265,7 @@ export const elements = {
   blockNoteEditor: '#bn-notes-scroll-container .bn-editor',
   blockNoteEditable: '#bn-notes-scroll-container .bn-editor[contenteditable="true"]',
   blockNoteReadOnly: '#bn-notes-scroll-container .bn-editor[contenteditable="false"]',
+  blockNoteSideMenu: '#bn-notes-scroll-container .bn-side-menu',
   blockNoteToolbar: 'div[data-test="blockNoteToolbar"]',
   blockNoteUnderlineButton: 'div[data-test="blockNoteToolbar"] button[aria-label="Underline"]',
   notesConnectionError: '[data-test="notesError"]',

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.spec.ts
@@ -19,4 +19,8 @@ test.describe.parallel('Shared Notes - BlockNote', { tag: '@ci' }, () => {
   test("Collaboration cursor must not embed a user's name in a link", async () => {
     await blockNoteSharedNotes.collaborationCursorMustNotEmbedInLink();
   });
+
+  test('Side menu must hide outside the editor', async () => {
+    await blockNoteSharedNotes.sideMenuMustHideOutsideEditor();
+  });
 });

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -43,6 +43,8 @@ export class BlockNoteSharedNotes extends MultiUsers {
 
     await this.modPage.page.mouse.move(editorBox.x + editorBox.width + 130, blockY);
     await expect(sideMenu, 'should keep the side menu hidden on later mouse movement outside the editor').toBeHidden();
+
+    await this.modPage.waitAndClick(e.hideNotesLabel);
   }
 
   // Reproduces issue #25225: when a remote user's caret sits inside a link, that

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -15,6 +15,36 @@ import {
 const LINK_URL = 'https://github.com/bigbluebutton/bigbluebutton/issues/25175';
 
 export class BlockNoteSharedNotes extends MultiUsers {
+  async sideMenuMustHideOutsideEditor() {
+    await startBlockNoteSharedNotes(this.modPage);
+
+    const editor = getBlockNoteEditorLocator(this.modPage);
+    await editor.click();
+    await this.modPage.page.keyboard.type('First block');
+    await this.modPage.page.keyboard.press('Enter');
+    await this.modPage.page.keyboard.type('Second block');
+
+    const firstBlock = editor.locator('.bn-block-outer').first();
+    const editorBox = await editor.boundingBox();
+    const firstBlockBox = await firstBlock.boundingBox();
+    expect(editorBox, 'BlockNote editor should have a bounding box').not.toBeNull();
+    expect(firstBlockBox, 'first BlockNote block should have a bounding box').not.toBeNull();
+    if (!editorBox || !firstBlockBox) return;
+
+    const blockY = firstBlockBox.y + firstBlockBox.height / 2;
+    await this.modPage.page.mouse.move(firstBlockBox.x + firstBlockBox.width / 2, blockY);
+    const sideMenu = this.modPage.page.locator(e.blockNoteSideMenu);
+    await expect(sideMenu, 'should display the side menu while hovering a block').toBeVisible();
+
+    // Regression test for #25575: BlockNote listens for mouse movement on the
+    // whole document and used to re-open the menu near a block, outside the editor.
+    await this.modPage.page.mouse.move(editorBox.x + editorBox.width + 120, blockY);
+    await expect(sideMenu, 'should hide the side menu outside the editor').toBeHidden();
+
+    await this.modPage.page.mouse.move(editorBox.x + editorBox.width + 130, blockY);
+    await expect(sideMenu, 'should keep the side menu hidden on later mouse movement outside the editor').toBeHidden();
+  }
+
   // Reproduces issue #25225: when a remote user's caret sits inside a link, that
   // user's collaboration-cursor name (and the U+2060 word-joiner separators around
   // it) must NOT be embedded in the link's text or href as seen by other users.

--- a/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
+++ b/bigbluebutton-tests/playwright/sharednotes/blocknote/blocknote.ts
@@ -44,6 +44,18 @@ export class BlockNoteSharedNotes extends MultiUsers {
     await this.modPage.page.mouse.move(editorBox.x + editorBox.width + 130, blockY);
     await expect(sideMenu, 'should keep the side menu hidden on later mouse movement outside the editor').toBeHidden();
 
+    await this.modPage.page.mouse.move(firstBlockBox.x + firstBlockBox.width / 2, blockY);
+    const dragHandle = sideMenu.getByRole('button', { name: 'Open block menu' });
+    await expect(dragHandle, 'should display the drag handle inside the editor').toBeVisible();
+    await dragHandle.click();
+    const blockMenu = this.modPage.page.getByRole('menu');
+    await expect(blockMenu, 'should open the block menu from the drag handle').toBeVisible();
+
+    await this.modPage.page.mouse.move(editorBox.x + editorBox.width + 120, blockY);
+    await expect(sideMenu, 'should keep the frozen side menu visible outside the editor').toBeVisible();
+    await expect(blockMenu, 'should keep the frozen block menu open outside the editor').toBeVisible();
+    await this.modPage.page.keyboard.press('Escape');
+
     await this.modPage.waitAndClick(e.hideNotesLabel);
   }
 


### PR DESCRIPTION
### What does this PR do?

backports #25672 changes to v3.0.x-develop:

_Fixes two BlockNote side-menu problems in the shared notes editor:_

_Side menu visible outside the editor (the reported bug): BlockNote's SideMenuExtension listens for mousemove on the whole document and opens the drag-handle/plus menu whenever the pointer is vertically level with a block, even when the pointer is over unrelated meeting UI (whiteboard, chat, etc.). This PR adds a document-level mousemove listener (bubble phase) that calls the public hideMenuIfNotFrozen() API whenever the event target is outside the notes editor wrapper. Frozen menus (an open drag-handle dropdown) are intentionally preserved._

_Side-menu sizing: documents (in a code comment) that BlockNote 0.53 centers the side menu with floating-ui offsets that assume its default 30px height, so no CSS height override is applied._

_Adds a Playwright regression test (sideMenuMustHideOutsideEditor), including the frozen-menu-preserved path and a later-movement assertion (the actual failure mode of the issue)._