### PR TITLE
fix(livekit): in-depth pass over reconnection, recovery and resiliency for LiveKit bridges

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/LockSettingsUtil.scala
@@ -150,6 +150,7 @@ object LockSettingsUtil {
           liveMeeting.props.meetingProp.intId,
           user.intId,
           webcam.streamId,
+          CameraHdlrHelpers.CAM_EJECTED_BY_LOCK,
           outGW
         )
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LiveKitParticipantLeftEvtMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/LiveKitParticipantLeftEvtMsgHdlr.scala
@@ -3,9 +3,8 @@ package org.bigbluebutton.core.apps.users
 import org.bigbluebutton.common2.msgs._
 import org.bigbluebutton.core.apps.ScreenshareModel
 import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x
-import org.bigbluebutton.core.apps.webcam.CameraHdlrHelpers
 import org.bigbluebutton.core.db.ScreenshareDAO
-import org.bigbluebutton.core.models.{ Users2x, VoiceUsers, Webcams }
+import org.bigbluebutton.core.models.{ Users2x, VoiceUsers }
 import org.bigbluebutton.core.running.{ BaseMeetingActor, LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.message.senders.MsgBuilder
 
@@ -53,10 +52,6 @@ trait LiveKitParticipantLeftEvtMsgHdlr {
           leftVoiceConf = true
         )
         outGW.send(eventUserVoiceStatus)
-      }
-
-      Webcams.findWebcamsForUser(liveMeeting.webcams, userId) foreach { webcam =>
-        CameraHdlrHelpers.stopBroadcastedCam(liveMeeting, meetingId, userId, webcam.streamId, outGW)
       }
 
       if (isPresenter && ScreenshareModel.isBroadcastingRTMP(liveMeeting.screenshareModel)) {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/users/UsersApp.scala
@@ -13,6 +13,7 @@ import org.bigbluebutton.core.models._
 import org.bigbluebutton.core.running.{LiveMeeting, OutMsgRouter}
 import org.bigbluebutton.core2.message.senders.{MsgBuilder, Sender}
 import org.bigbluebutton.core.apps.screenshare.ScreenshareApp2x
+import org.bigbluebutton.core.apps.webcam.CameraHdlrHelpers
 import org.bigbluebutton.core.db.{ChatMessageDAO, MediaGroupUserDAO, UserDAO, UserStateDAO}
 import org.bigbluebutton.core2.MeetingStatus2x
 import org.bigbluebutton.core.graphql.GraphqlMiddleware
@@ -178,6 +179,9 @@ object UsersApp {
       }
       UserStateDAO.updateEjected(meetingId, userId, reason, reasonCode, ejectedBy)
       removeUserLiveKitMemberships(liveMeeting, meetingId, userId, outGW)
+      Webcams.findWebcamsForUser(liveMeeting.webcams, userId) foreach { webcam =>
+        CameraHdlrHelpers.stopBroadcastedCam(liveMeeting, meetingId, userId, webcam.streamId, outGW)
+      }
     }
 
     for {

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/CameraHdlrHelpers.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/CameraHdlrHelpers.scala
@@ -7,8 +7,13 @@ import org.bigbluebutton.core.apps.{ PermissionCheck, RightsManagementTrait }
 import org.bigbluebutton.core.models.{ Users2x, Webcams, WebcamStream }
 import org.bigbluebutton.core.running.{ LiveMeeting, OutMsgRouter }
 import org.bigbluebutton.core2.MeetingStatus2x
+import org.bigbluebutton.core.db.NotificationDAO
+import org.bigbluebutton.core2.message.senders.MsgBuilder
 
 object CameraHdlrHelpers extends SystemConfiguration with RightsManagementTrait {
+  val CAM_EJECTED_BY_MODERATOR = "app.video.ejectedByModerator"
+  val CAM_EJECTED_BY_LOCK = "app.video.ejectedByLockSettings"
+
   def isCameraBroadcastAllowed(
       liveMeeting: LiveMeeting,
       meetingId:   String,
@@ -168,6 +173,7 @@ object CameraHdlrHelpers extends SystemConfiguration with RightsManagementTrait 
       meetingId: String,
       userId:    String,
       streamId:  String,
+      reason:    String,
       outGW:     OutMsgRouter
   ): Unit = {
     val routing = collection.immutable.HashMap("sender" -> "bbb-apps-akka")
@@ -178,6 +184,17 @@ object CameraHdlrHelpers extends SystemConfiguration with RightsManagementTrait 
     val msgEvent = BbbCommonEnvCoreMsg(envelope, event)
 
     outGW.send(msgEvent)
+    val notifyEvent = MsgBuilder.buildNotifyUserInMeetingEvtMsg(
+      userId,
+      meetingId,
+      "info",
+      "video",
+      reason,
+      "Notification that a moderator or a lock setting stopped a user's camera",
+      Map("streamId" -> streamId)
+    )
+    outGW.send(notifyEvent)
+    NotificationDAO.insert(notifyEvent)
   }
 
   def requestCamSubscriptionEjection(

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/EjectUserCamerasCmdMsgHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/webcam/EjectUserCamerasCmdMsgHdlr.scala
@@ -40,6 +40,7 @@ trait EjectUserCamerasCmdMsgHdlr {
           meetingId,
           userId,
           webcam.streamId,
+          CameraHdlrHelpers.CAM_EJECTED_BY_MODERATOR,
           bus.outGW
         )
       }

--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/running/MeetingActor.scala
@@ -22,7 +22,7 @@ import org.bigbluebutton.core.apps.audiocaptions.AudioCaptionsApp2x
 import org.bigbluebutton.core.apps.timer.TimerApp2x
 import org.bigbluebutton.core.apps.presentation.PresentationApp2x
 import org.bigbluebutton.core.apps.users.UsersApp2x
-import org.bigbluebutton.core.apps.webcam.WebcamApp2x
+import org.bigbluebutton.core.apps.webcam.{ CameraHdlrHelpers, WebcamApp2x }
 import org.bigbluebutton.core.apps.whiteboard.WhiteboardApp2x
 import org.bigbluebutton.core.bus._
 import org.bigbluebutton.core.models.{ Users2x, VoiceUsers, _ }
@@ -1172,6 +1172,10 @@ class MeetingActor(
         // Their media session might outlive them (for good reason - e.g.: smoother reconns).
         // Fence them until restored or ejected.
         liveMeeting.voiceUserReconciler.fenceRemovedUser(liveMeeting, outGW, u.intId)
+
+        Webcams.findWebcamsForUser(liveMeeting.webcams, u.intId) foreach { webcam =>
+          CameraHdlrHelpers.stopBroadcastedCam(liveMeeting, props.meetingProp.intId, u.intId, webcam.streamId, outGW)
+        }
 
         val updatedRegUser = RegisteredUsers.updateUserJoin(liveMeeting.registeredUsers, ru, joined = false)
         UserDAO.update(updatedRegUser)

--- a/bbb-webrtc-sfu.placeholder.sh
+++ b/bbb-webrtc-sfu.placeholder.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-git clone --branch v2.25.0-beta.0 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu
+git clone --branch v2.25.0-beta.1 --depth 1 https://github.com/bigbluebutton/bbb-webrtc-sfu bbb-webrtc-sfu

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -156,6 +156,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     this.handleLocalTrackPublished = this.handleLocalTrackPublished.bind(this);
     this.handleLocalTrackUnpublished = this.handleLocalTrackUnpublished.bind(this);
     this.handleRoomReconnected = this.handleRoomReconnected.bind(this);
+    this.handleRoomConnected = this.handleRoomConnected.bind(this);
     this.unpublishRequest = null;
     this.isPublishPending = false;
     this.publishGeneration = 0;
@@ -662,6 +663,46 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     // A full reconnect republishes local tracks using the SDK's local mute
     // state, which may have drifted from BBB's authoritative state. Reinforce.
     this.reinforceMuteState('room_reconnected');
+    this.reconcileMicPublication('room_reconnected');
+  }
+
+  private handleRoomConnected(): void {
+    this.reconcileMicPublication('room_connected');
+  }
+
+  // The mic room can come back after an operation aimed at it already failed:
+  // a rejoin after a server-side eject reconnects the same Room, a full
+  // reconnect cancels a pending publish. Nothing replays those, so re-derive
+  // the publication from the last intent once the room is usable again.
+  private reconcileMicPublication(reason: string): void {
+    if (this.shouldBeMuted || this.joinInFlight) return;
+    if (this.inputDeviceId === 'listen-only' || !this.originalStream) return;
+    if (this.hasMicrophoneTrack()) return;
+
+    logger.info({
+      logCode: 'livekit_audio_mic_reconciled',
+      extraInfo: {
+        bridge: this.bridgeName,
+        role: this.role,
+        reason,
+        inputDeviceId: this.inputDeviceId,
+        streamData: MediaStreamUtils.getMediaStreamLogData(this.originalStream),
+      },
+    }, `LiveKit: republishing the microphone after room connect - ${reason}`);
+
+    this.publish(this.originalStream).catch((error) => {
+      logger.error({
+        logCode: 'livekit_audio_mic_reconcile_error',
+        extraInfo: {
+          errorMessage: (error as Error)?.message,
+          errorName: (error as Error)?.name,
+          errorStack: (error as Error)?.stack,
+          bridge: this.bridgeName,
+          role: this.role,
+          reason,
+        },
+      }, `LiveKit: failed to republish the microphone after room connect - ${(error as Error)?.message}`);
+    });
   }
 
   // Re-assert the desired muted state onto the local microphone track. LiveKit
@@ -722,6 +763,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
   // defenses + publish logging).
   private attachMicObservers(room: Room): void {
     this.detachMicObservers(room);
+    room.on(RoomEvent.Connected, this.handleRoomConnected);
     room.on(RoomEvent.Reconnected, this.handleRoomReconnected);
     room.localParticipant.on(ParticipantEvent.TrackMuted, this.handleLocalTrackMuted);
     room.localParticipant.on(ParticipantEvent.TrackUnmuted, this.handleLocalTrackUnmuted);
@@ -730,6 +772,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
   }
 
   private detachMicObservers(room: Room): void {
+    room.off(RoomEvent.Connected, this.handleRoomConnected);
     room.off(RoomEvent.Reconnected, this.handleRoomReconnected);
     room.localParticipant.off(ParticipantEvent.TrackMuted, this.handleLocalTrackMuted);
     room.localParticipant.off(ParticipantEvent.TrackUnmuted, this.handleLocalTrackUnmuted);

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -1887,7 +1887,22 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
           micRoom,
           micRoom.localParticipant.setMicrophoneEnabled(true, constraints, publishOptions),
         );
-        this.originalStream = this.inputStream;
+
+        if (this.publicationTrackStream) {
+          // setMicrophoneEnabled creates a new stream in this path (publicationTrackStream)
+          this.originalStream = this.publicationTrackStream;
+        } else {
+          logger.warn({
+            logCode: 'livekit_audio_publish_pub_stream_missing',
+            extraInfo: {
+              bridge: this.bridgeName,
+              role: this.role,
+              inputDeviceId: this.inputDeviceId,
+              streamData: MediaStreamUtils.getMediaStreamLogData(this.originalStream),
+            },
+          }, 'LiveKit: published without a publication stream, keeping the previous capture');
+        }
+
         logger.debug({
           logCode: 'livekit_audio_publish_without_stream',
           extraInfo: {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -183,6 +183,13 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     this.observeLiveKitEvents();
   }
 
+  // Which room the microphone is actually published into. A breakout listen-in
+  // moves it off the primary, and anything reasoning about "is my audio
+  // interrupted" has to follow it rather than watch the primary room.
+  get micRoomKey(): MembershipKey {
+    return this.activeMicRoomKey;
+  }
+
   get clientSessionId(): string {
     if (this.clientSessionUUID === '0') {
       this.clientSessionUUID = sessionStorage.getItem('clientSessionUUID') || '0';

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -444,6 +444,20 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     ).filter((publication) => publication.source === Track.Source.Microphone);
   }
 
+  // The SDK re-acquires its own captures on unmute, so those are always
+  // resumable; a track the bridge handed it (user provided) will not be
+  // touched and has to be usable already.
+  private static canUnmuteInPlace(publication: LocalTrackPublication): boolean {
+    const { track } = publication;
+
+    if (!track) return false;
+    if (!track.isUserProvided) return true;
+
+    const capture = track.mediaStreamTrack;
+
+    return capture?.readyState === 'live' && !capture.muted;
+  }
+
   private static publicationMatchesDevice(
     publication: LocalTrackPublication | null,
     deviceId: string | null | undefined,
@@ -1358,9 +1372,14 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         (pub) => LiveKitAudioBridge.publicationMatchesDevice(pub, this.inputDeviceId),
       );
 
-      // Track is published but muted - just unmute it
-      if (currentPubs.length > 0) {
-        const mutedPubs = currentPubs.filter((pub) => pub.isMuted);
+      // Track is published but muted - unmute it in place only where that will
+      // carry audio again, otherwise fall through and re-acquire.
+      const resumablePubs = currentPubs.filter(
+        (pub) => LiveKitAudioBridge.canUnmuteInPlace(pub),
+      );
+
+      if (resumablePubs.length > 0) {
+        const mutedPubs = resumablePubs.filter((pub) => pub.isMuted);
 
         if (mutedPubs.length > 0) {
           mutedPubs.forEach((pub) => pub.unmute());
@@ -1376,9 +1395,11 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
             },
           }, `LiveKit: unmuting audio track - ${trackName}`);
         }
-      } else if (trackPubs.length === 0 && this.originalStream) {
-        // Track was unpublished on previous mute toggle, so publish again.
-        // Only publish if we have an original stream (audio was shared before).
+      } else if (this.originalStream && (trackPubs.length === 0 || currentPubs.length > 0)) {
+        // Either nothing is published (unpublished on a previous mute toggle) or
+        // this device's publication cannot carry audio again. Publish either
+        // way; doPublish drops a stale publication first, and its
+        // inactive-stream fallback re-acquires a capture that has ended.
         this.publish(this.originalStream).catch(handleMuteError);
         logger.debug({
           logCode: 'livekit_audio_track_unmute_publish',

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -475,14 +475,14 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
   private isTrackPublishedWithStream(stream: MediaStream | null): boolean {
     if (!stream) return false;
 
-    const pubs = this.getLocalMicTrackPubs();
+    const trackIds = stream.getAudioTracks().map((track) => track.id);
 
-    if (pubs.length === 0) return false;
+    if (trackIds.length === 0) return false;
 
-    return pubs.some((pub) => {
-      const pubStream = pub.track?.mediaStream;
+    return this.getLocalMicTrackPubs().some((pub) => {
+      const track = pub.track?.mediaStreamTrack;
 
-      return pubStream?.id === stream.id && pubStream?.active;
+      return !!track && trackIds.includes(track.id) && track.readyState === 'live';
     });
   }
 
@@ -1688,6 +1688,8 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
       }, 'LiveKit: failed to unpublish audio track before publish');
     }
 
+    let micRoom: Room | undefined;
+
     try {
       // @ts-ignore
       const LIVEKIT_SETTINGS = window.meetingClientSettings.public.media?.livekit?.audio;
@@ -1716,7 +1718,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         }, 'LiveKit: audio stream is inactive, fallback');
       }
 
-      const micRoom = this.activeMicRoom ?? this.resolvePrimaryRoom();
+      micRoom = this.activeMicRoom ?? this.resolvePrimaryRoom();
 
       if (!micRoom) {
         logger.warn({
@@ -1733,6 +1735,23 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
       // when this runs. Wait for room conn here.
       await waitForRoomConnection(micRoom);
 
+      // The wait also ends when the SDK reconnects, which may cause
+      // the input stream to be republished (see handleSignalRestarted
+      // in the SDK's Room.ts) via republishAllTracks. Skip if that's the case.
+      if (inputStream && this.isTrackPublishedWithStream(inputStream)) {
+        logger.debug({
+          logCode: 'livekit_audio_publish_republished_skip',
+          extraInfo: {
+            bridge: this.bridgeName,
+            role: this.role,
+            inputDeviceId: this.inputDeviceId,
+            streamData: MediaStreamUtils.getMediaStreamLogData(inputStream),
+          },
+        }, 'LiveKit: stream republished while waiting for the room, skipping publish');
+
+        return;
+      }
+
       if (inputStream && inputStream.active) {
         // Get tracks from the stream and publish them. Map into an array of
         // Promise objects and wait for all of them to resolve.
@@ -1745,9 +1764,10 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
             streamData: MediaStreamUtils.getMediaStreamLogData(inputStream),
           },
         }, 'LiveKit: publishing audio track with stream');
+        const { localParticipant } = micRoom;
         const trackPublishers = inputStream.getAudioTracks()
           .map((track) => {
-            return micRoom.localParticipant.publishTrack(track, publishOptions);
+            return localParticipant.publishTrack(track, publishOptions);
           });
         await LiveKitAudioBridge.bindToRoomLiveness(micRoom, Promise.all(trackPublishers));
       } else {
@@ -1773,6 +1793,8 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
 
       this.audioPublished();
     } catch (error) {
+      const publishedAnyway = !!inputStream && this.isTrackPublishedWithStream(inputStream);
+
       logger.error({
         logCode: 'livekit_audio_publish_error',
         extraInfo: {
@@ -1783,8 +1805,20 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
           role: this.role,
           inputDeviceId: this.inputDeviceId,
           streamData: MediaStreamUtils.getMediaStreamLogData(inputStream || this.originalStream),
+          publishedAnyway,
         },
       }, 'LiveKit: failed to publish audio track');
+
+      // A timeout on a stream that is published anyway is most likely a duplicate publish
+      // request, not a bugged room. No need to trigger the fatal error handling if that's
+      // the case
+      if (publishedAnyway) {
+        const micPub = micRoom?.localParticipant.getTrackPublication(Track.Source.Microphone);
+        this.currentMicTrack = micPub?.track?.mediaStreamTrack ?? undefined;
+        this.audioPublished();
+
+        return;
+      }
 
       if (LiveKitAudioBridge.isFatalPublishError(error as Error)) {
         if (this.micSwitchGeneration === switchGeneration) {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -33,12 +33,19 @@ import {
 } from '/imports/ui/services/livekit';
 import { getLiveKitStats } from '/imports/ui/services/livekit/stats';
 import MediaStreamUtils from '/imports/utils/media-stream-utils';
+import { consumeMuteCommand } from './mute-intent';
 
 const BRIDGE_NAME = 'livekit';
 const SENDRECV_ROLE = 'sendrecv';
 const PUBLISH_OP = 'publish';
 const UNPUBLISH_OP = 'unpublish';
 const DEFAULT_UNPUBLISH_AFTER_MUTE_MS = 5000;
+// Time window after a reconnect during which the bridge ignores the server's
+// mute state.
+const RECONNECT_SERVER_MUTE_WINDOW_MS = 3000;
+// Time for the reconnect's republish to land before the bridge reads BBB's
+// mute state and forces reconciliation
+const STATE_RECONCILE_DELAY_MS = 2000;
 
 interface JoinOptions {
   inputStream: MediaStream;
@@ -115,6 +122,13 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
   // setSenderTrackEnabled.
   private shouldBeMuted: boolean;
 
+  // The last known server-originated mute state
+  private lastServerMuteState: boolean;
+
+  private reconnectingSince: number | null;
+
+  private serverStateReconcile: ReturnType<typeof setTimeout> | null;
+
   private static assembleTrackName(
     clientSessionId: string,
     deviceId: string | null | undefined,
@@ -156,11 +170,15 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     this.handleLocalTrackPublished = this.handleLocalTrackPublished.bind(this);
     this.handleLocalTrackUnpublished = this.handleLocalTrackUnpublished.bind(this);
     this.handleRoomReconnected = this.handleRoomReconnected.bind(this);
+    this.handleRoomReconnecting = this.handleRoomReconnecting.bind(this);
     this.handleRoomConnected = this.handleRoomConnected.bind(this);
     this.unpublishRequest = null;
     this.isPublishPending = false;
     this.publishGeneration = 0;
     this.shouldBeMuted = true;
+    this.reconnectingSince = null;
+    this.lastServerMuteState = true;
+    this.serverStateReconcile = null;
 
     this.observeLiveKitEvents();
   }
@@ -659,7 +677,14 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     }, `LiveKit: audio track unpublished - ${trackSid}`);
   }
 
+  private handleRoomReconnecting(): void {
+    this.reconnectingSince = Date.now();
+    this.clearServerStateReconcile();
+  }
+
   private handleRoomReconnected(): void {
+    this.reconnectingSince = null;
+    this.scheduleServerStateReconcile();
     // A full reconnect republishes local tracks using the SDK's local mute
     // state, which may have drifted from BBB's authoritative state. Reinforce.
     this.reinforceMuteState('room_reconnected');
@@ -667,7 +692,52 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
   }
 
   private handleRoomConnected(): void {
+    this.reconnectingSince = null;
+    this.scheduleServerStateReconcile();
     this.reconcileMicPublication('room_connected');
+  }
+
+  // A full LK reconnect unpublishes and republishes the mic; the server reads the
+  // unpublish as a mute, and that means a mute - ie a reconnect while unmuted
+  // would leave the user muted once it is over.
+  // This check exists so that we can try to persist the user's mute state across
+  // a reconnect by ignoring the server's state for a short window - until it elapses
+  // or the reconn succeeds.
+  private isReconnectTransientMute(): boolean {
+    return this.activeMicRoom?.state === ConnectionState.Reconnecting
+      && this.reconnectingSince !== null
+      && Date.now() - this.reconnectingSince < RECONNECT_SERVER_MUTE_WINDOW_MS;
+  }
+
+  private clearServerStateReconcile(): void {
+    if (this.serverStateReconcile) {
+      clearTimeout(this.serverStateReconcile);
+      this.serverStateReconcile = null;
+    }
+  }
+
+  // A voice state the bridge ignores during reconns should be adopted once the room is stable again
+  private scheduleServerStateReconcile(): void {
+    this.clearServerStateReconcile();
+
+    this.serverStateReconcile = setTimeout(() => {
+      this.serverStateReconcile = null;
+
+      if (this.lastServerMuteState === this.shouldBeMuted) return;
+
+      logger.warn({
+        logCode: 'livekit_audio_mute_state_reconciled',
+        extraInfo: {
+          bridge: this.bridgeName,
+          role: this.role,
+          shouldBeMuted: this.shouldBeMuted,
+          lastServerMuteState: this.lastServerMuteState,
+        },
+      }, 'LiveKit: adopting the server voice state after a reconnect');
+
+      this.shouldBeMuted = this.lastServerMuteState;
+      this.reinforceMuteState('server_state_reconcile');
+    }, STATE_RECONCILE_DELAY_MS);
   }
 
   // The mic room can come back after an operation aimed at it already failed:
@@ -709,8 +779,11 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
   // reconnects/republishes, and out-of-band track unmutes, can leave the track
   // sending audio while BBB's state is muted.
   private reinforceMuteState(reason: string): void {
-    if (!this.shouldBeMuted) return;
-    if (!this.hasMicrophoneTrack() || this.isLocalPublicationMuted()) return;
+    if (!this.hasMicrophoneTrack()) return;
+
+    const publicationMuted = this.isLocalPublicationMuted();
+
+    if (this.shouldBeMuted === publicationMuted) return;
 
     logger.warn({
       logCode: 'livekit_audio_mute_reinforced',
@@ -718,14 +791,16 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         bridge: this.bridgeName,
         role: this.role,
         reason,
+        shouldBeMuted: this.shouldBeMuted,
+        publicationMuted,
       },
-    }, `LiveKit: reinforcing muted state on local audio track - ${reason}`);
+    }, `LiveKit: reinforcing mute state on local audio track - ${reason}`);
 
     const micRoom = this.activeMicRoom ?? this.resolvePrimaryRoom();
 
     if (!micRoom) return;
 
-    micRoom.localParticipant.setMicrophoneEnabled(false).catch((error) => {
+    micRoom.localParticipant.setMicrophoneEnabled(!this.shouldBeMuted).catch((error) => {
       logger.error({
         logCode: 'livekit_audio_mute_reinforce_error',
         extraInfo: {
@@ -764,6 +839,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
   private attachMicObservers(room: Room): void {
     this.detachMicObservers(room);
     room.on(RoomEvent.Connected, this.handleRoomConnected);
+    room.on(RoomEvent.Reconnecting, this.handleRoomReconnecting);
     room.on(RoomEvent.Reconnected, this.handleRoomReconnected);
     room.localParticipant.on(ParticipantEvent.TrackMuted, this.handleLocalTrackMuted);
     room.localParticipant.on(ParticipantEvent.TrackUnmuted, this.handleLocalTrackUnmuted);
@@ -773,6 +849,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
 
   private detachMicObservers(room: Room): void {
     room.off(RoomEvent.Connected, this.handleRoomConnected);
+    room.off(RoomEvent.Reconnecting, this.handleRoomReconnecting);
     room.off(RoomEvent.Reconnected, this.handleRoomReconnected);
     room.localParticipant.off(ParticipantEvent.TrackMuted, this.handleLocalTrackMuted);
     room.localParticipant.off(ParticipantEvent.TrackUnmuted, this.handleLocalTrackUnmuted);
@@ -784,6 +861,8 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
     if (previous === target) return;
     if (previous) this.detachMicObservers(previous);
 
+    this.reconnectingSince = null;
+    this.clearServerStateReconcile();
     this.attachMicObservers(target);
   }
 
@@ -1207,7 +1286,11 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
   setSenderTrackEnabled(shouldEnable: boolean): void {
     // Record the latest mute intent so reconnect/republish/out-of-band track
     // unmutes can be reconciled against it (see reinforceMuteState).
+    const previousIntent = this.shouldBeMuted;
     this.shouldBeMuted = !shouldEnable;
+    this.lastServerMuteState = this.shouldBeMuted;
+    const clientInitiated = previousIntent !== this.shouldBeMuted
+      && consumeMuteCommand(this.shouldBeMuted);
     const trackPubs = this.getLocalMicTrackPubs();
     const isCurrentlyMuted = this.isLocalPublicationMuted();
     const hasPublishedTrack = this.hasMicrophoneTrack();
@@ -1300,6 +1383,22 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         }, 'LiveKit: audio track unmute no-op - no matching pubs or no original stream');
       }
     } else {
+      if (!clientInitiated && this.isReconnectTransientMute()) {
+        this.shouldBeMuted = previousIntent;
+        this.clearUnpublishRequest();
+        logger.warn({
+          logCode: 'livekit_audio_mute_ignored_reconnecting',
+          extraInfo: {
+            bridge: this.bridgeName,
+            role: this.role,
+            inputDeviceId: this.inputDeviceId,
+            previousIntent,
+          },
+        }, 'LiveKit: mute ignored while the room reconnects');
+
+        return;
+      }
+
       if (isCurrentlyMuted || !hasPublishedTrack) return;
 
       // Track is published and unmuted - mute it
@@ -2060,6 +2159,7 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
         return false;
       })
       .finally(() => {
+        this.clearServerStateReconcile();
         this.originalStream = null;
         this.currentMicTrack = undefined;
         this.isPublishPending = false;

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -603,12 +603,22 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
       this.clearUnpublishRequest();
 
       this.unpublishRequest = setTimeout(() => {
+        this.unpublishRequest = null;
         // If the publication is unmuted, we don't need to unpublish anymore
         // (this unpublish request is only set if the publication is muted)
         if (!this.hasMicrophoneTrack() || !this.isLocalPublicationMuted()) return;
 
-        this.unpublish();
-        this.unpublishRequest = null;
+        this.unpublish().catch((error) => {
+          logger.warn({
+            logCode: 'livekit_audio_unpublish_after_mute_error',
+            extraInfo: {
+              errorMessage: (error as Error)?.message,
+              errorName: (error as Error)?.name,
+              bridge: this.bridgeName,
+              role: this.role,
+            },
+          }, `LiveKit: unpublish after mute failed - ${(error as Error)?.message}`);
+        });
       }, unpublishAfterMuteMs);
     }
   }
@@ -680,6 +690,9 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
   private handleRoomReconnecting(): void {
     this.reconnectingSince = Date.now();
     this.clearServerStateReconcile();
+    // The SDK replaces its PeerConnections on a full reconnect; a pending
+    // unpublish would target a sender the new connection never created (and fail).
+    this.clearUnpublishRequest();
   }
 
   private handleRoomReconnected(): void {

--- a/bigbluebutton-html5/imports/api/audio/client/bridge/mute-intent.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/mute-intent.ts
@@ -1,0 +1,26 @@
+// This is a simple registrar to track whether a mute action is one the client
+// itself requested, as opposed to one derived from a voice state change the
+// server made (e.g.: mod mute, reconnect).
+const COMMAND_LIFETIME_MS = 5000;
+
+let pendingCommand: { muted: boolean, at: number } | null = null;
+
+export const stampMuteCommand = (muted: boolean): void => {
+  pendingCommand = { muted, at: Date.now() };
+};
+
+export const consumeMuteCommand = (muted: boolean): boolean => {
+  if (pendingCommand === null) return false;
+
+  if (Date.now() - pendingCommand.at >= COMMAND_LIFETIME_MS) {
+    pendingCommand = null;
+
+    return false;
+  }
+
+  if (pendingCommand.muted !== muted) return false;
+
+  pendingCommand = null;
+
+  return true;
+};

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -687,6 +687,7 @@ export interface LiveKitSettings {
   url?: string
   selectiveSubscription?: SelectiveSubscriptionConfig
   logLevel?: LogLevel
+  sdkLogBridge?: boolean
   roomOptions?: Partial<InternalRoomOptions>
   reconnectOnFatalFailures?: boolean
   forceRelay?: boolean

--- a/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
+++ b/bigbluebutton-html5/imports/ui/Types/meetingClientSettings.ts
@@ -690,6 +690,7 @@ export interface LiveKitSettings {
   sdkLogBridge?: boolean
   roomOptions?: Partial<InternalRoomOptions>
   reconnectOnFatalFailures?: boolean
+  negotiationProbe?: boolean
   forceRelay?: boolean
   forceRelayOnFirefox?: boolean
   audio?: LiveKitAudioSettings

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/LiveSelection.tsx
@@ -15,7 +15,7 @@ import {
   notify,
   truncateDeviceName,
 } from '../service';
-import MuteToggle from './muteToggle';
+import MuteToggle, { type MuteToggleProps } from './muteToggle';
 import ListenOnly from './listenOnly';
 import { PluginsContext } from '/imports/ui/components/components-data/plugin-context/context';
 
@@ -78,16 +78,8 @@ const intlMessages = defineMessages({
   },
 });
 
-interface MuteToggleProps {
-  talking: boolean;
-  muted: boolean;
-  disabled: boolean;
-  isAudioLocked: boolean;
-  toggleMuteMicrophone: (muted: boolean, toggleVoice: (userId: string, muted: boolean) => void) => void;
-  away: boolean;
-}
-
-interface LiveSelectionProps extends MuteToggleProps {
+interface LiveSelectionProps extends Pick<MuteToggleProps,
+  'talking' | 'muted' | 'disabled' | 'mediaInterrupted' | 'isAudioLocked' | 'toggleMuteMicrophone' | 'away'> {
   listenOnly: boolean;
   inputDevices: MediaDeviceInfo[];
   outputDevices: MediaDeviceInfo[];
@@ -113,6 +105,7 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
   talking,
   muted,
   disabled,
+  mediaInterrupted,
   isAudioLocked,
   toggleMuteMicrophone,
   away,
@@ -355,6 +348,7 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
           talking={talking}
           muted={muted}
           disabled={disabled || isAudioLocked}
+          mediaInterrupted={mediaInterrupted}
           isAudioLocked={isAudioLocked}
           toggleMuteMicrophone={toggleMuteMicrophone}
           away={away}
@@ -376,6 +370,7 @@ export const LiveSelection: React.FC<LiveSelectionProps> = ({
                   talking={talking}
                   muted={muted}
                   disabled={disabled || isAudioLocked}
+                  mediaInterrupted={mediaInterrupted}
                   isAudioLocked={isAudioLocked}
                   toggleMuteMicrophone={toggleMuteMicrophone}
                   away={away}

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/buttons/muteToggle.tsx
@@ -38,10 +38,11 @@ const intlMessages = defineMessages({
   },
 });
 
-interface MuteToggleProps {
+export interface MuteToggleProps {
   talking: boolean;
   muted: boolean;
   disabled: boolean;
+  mediaInterrupted: boolean;
   isAudioLocked: boolean;
   toggleMuteMicrophone: (muted: boolean, toggleVoice: (userId: string, muted: boolean) => void) => void;
   away: boolean;
@@ -57,6 +58,7 @@ export const MuteToggle: React.FC<MuteToggleProps> = ({
   talking,
   muted,
   disabled,
+  mediaInterrupted,
   isAudioLocked,
   toggleMuteMicrophone,
   away,
@@ -104,6 +106,11 @@ export const MuteToggle: React.FC<MuteToggleProps> = ({
     ) return;
 
     if (action === 'down' && !isKeyDown.current) {
+      // Only unmuting the mic is refused while the media session is down as it is
+      // a no-op that may create an inconsistent state.
+      // Muting should still go through as it is partially effective locally.
+      if (mediaInterrupted) return;
+
       isKeyDown.current = true;
       startPushToTalk(toggleVoice);
     } else if (action === 'up') {
@@ -117,7 +124,7 @@ export const MuteToggle: React.FC<MuteToggleProps> = ({
     setTimeout(() => {
       muteLoadingState(false);
     }, 1000);
-  }, []);
+  }, [mediaInterrupted]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => handlePushToTalk('down', event);
@@ -129,11 +136,13 @@ export const MuteToggle: React.FC<MuteToggleProps> = ({
     return () => {
       if (cooldownTimerRef.current) {
         clearTimeout(cooldownTimerRef.current);
+        cooldownTimerRef.current = null;
+        cooldownActive.current = false;
       }
       document.removeEventListener('keydown', handleKeyDown);
       document.removeEventListener('keyup', handleKeyUp);
     };
-  }, []);
+  }, [handlePushToTalk]);
 
   useEffect(() => {
     muteLoadingState(false);
@@ -178,16 +187,16 @@ export const MuteToggle: React.FC<MuteToggleProps> = ({
       {/* eslint-disable-next-line jsx-a11y/no-access-key */}
       <Styled.MuteToggleButton
         onClick={onClickCallback}
-        disabled={disabled || isAudioLocked}
+        disabled={disabled || isAudioLocked || (mediaInterrupted && muted)}
         hideLabel
         label={label}
         aria-label={label}
-        color={!muted ? 'primary' : 'default'}
+        color={!muted && !mediaInterrupted ? 'primary' : 'default'}
         icon={muted ? 'mute' : 'unmute'}
         size={deviceInfo.isMobile ? 'md' : 'lg'}
         circle
         accessKey={toggleMuteShourtcut}
-        $talking={talking || undefined}
+        $talking={(talking && !mediaInterrupted) || undefined}
         animations={animations}
         loading={isMuteLoading}
         data-test={muted ? 'unmuteMicButton' : 'muteMicButton'}

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/component.tsx
@@ -71,6 +71,7 @@ interface InputStreamLiveSelectorProps extends InputStreamLiveSelectorContainerP
   inAudio: boolean;
   showMute: boolean;
   disabled: boolean;
+  mediaInterrupted: boolean;
   inputDeviceId: string;
   outputDeviceId: string;
   inputStream: string;
@@ -93,6 +94,7 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
   inAudio,
   showMute,
   disabled,
+  mediaInterrupted,
   inputDeviceId,
   outputDeviceId,
   inputStream,
@@ -200,6 +202,7 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
             talking={talking}
             muted={muted}
             disabled={disabled || isAudioLocked}
+            mediaInterrupted={mediaInterrupted}
             isAudioLocked={isAudioLocked}
             toggleMuteMicrophone={toggleMuteMicrophone}
             away={away}
@@ -214,6 +217,7 @@ const InputStreamLiveSelector: React.FC<InputStreamLiveSelectorProps> = ({
           <>
             {(isConnected && !listenOnly) && (
               <MuteToggle
+                mediaInterrupted={mediaInterrupted}
                 talking={talking}
                 muted={muted}
                 disabled={disabled || isAudioLocked}
@@ -293,6 +297,8 @@ const InputStreamLiveSelectorContainer: React.FC<InputStreamLiveSelectorContaine
   // @ts-ignore - temporary while hybrid (meteor+GraphQl)
   const supportsTransparentListenOnly = useReactiveVar(AudioManager._transparentListenOnlySupported.value) as boolean;
   const isConnected = useIsAudioConnected();
+  // @ts-ignore - temporary while hybrid (meteor+GraphQl)
+  const mediaInterrupted = useReactiveVar(AudioManager._isReconnecting.value) as boolean;
 
   const updateInputDevices = (devices: InputDeviceInfo[] = []) => {
     AudioManager.inputDevices = devices;
@@ -315,6 +321,7 @@ const InputStreamLiveSelectorContainer: React.FC<InputStreamLiveSelectorContaine
       showMute={(inAudio && !currentMeeting?.lockSettings?.disableMic) ?? false}
       isConnected={isConnected}
       disabled={isConnecting || isHangingUp}
+      mediaInterrupted={mediaInterrupted}
       inputDeviceId={inputDeviceId}
       outputDeviceId={outputDeviceId}
       inputStream={inputStream}

--- a/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/audio/audio-graphql/audio-controls/input-stream-live-selector/service.ts
@@ -1,4 +1,5 @@
 import { ReactiveVar, makeVar, useReactiveVar } from '@apollo/client';
+import { stampMuteCommand } from '/imports/api/audio/client/bridge/mute-intent';
 import getFromUserSettings from '/imports/ui/services/users-settings';
 import Storage from '/imports/ui/services/storage/session';
 import { useStorageKey } from '/imports/ui/services/storage/hooks';
@@ -75,6 +76,7 @@ const toggleMute = (
         extraInfo: { logType: actionType },
       }, 'microphone unmuted');
       Storage.setItem(storageKey, newMutedState);
+      stampMuteCommand(newMutedState);
 
       if (shouldRunLocalMute) AudioManager.unmute();
 
@@ -85,6 +87,7 @@ const toggleMute = (
         extraInfo: { logType: actionType },
       }, 'microphone muted');
       Storage.setItem(storageKey, newMutedState);
+      stampMuteCommand(newMutedState);
 
       if (shouldRunLocalMute) AudioManager.mute();
 

--- a/bigbluebutton-html5/imports/ui/components/livekit/base-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/base-room/component.tsx
@@ -97,9 +97,19 @@ const BaseLiveKitRoom: React.FC<BaseLiveKitRoomProps> = ({
       },
     }, `${logPrefix}: room disconnected, reason=${reason}`);
 
-    if (isOrphaningDisconnect(reason)) {
-      onTerminalDisconnect?.(reason);
+    if (!isOrphaningDisconnect(reason)) return;
+
+    if (onTerminalDisconnect) {
+      onTerminalDisconnect(reason);
+
+      return;
     }
+
+    // The SDK emits no error for a disconnect it will not retry, so the retry
+    // effect has nothing to act on; a room whose owner keeps it (the primary)
+    // is reconnected through that effect, so trigger it here
+    setConnError(new ForcedReconnectionError(`Terminal disconnect (reason=${reason})`));
+    setConnAttempts((p) => p + 1);
   }, [logPrefix, url, iceServers, connAttempts, membershipKey, onTerminalDisconnect]);
 
   const onError = useCallback((error: Error) => {

--- a/bigbluebutton-html5/imports/ui/components/livekit/base-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/base-room/component.tsx
@@ -19,6 +19,7 @@ import shouldForceRelay from '/imports/ui/components/livekit/utils';
 import { ForcedReconnectionError } from '/imports/ui/components/livekit/errors';
 import {
   LK_FATAL_ERROR_EVENT,
+  applyRoomOptions,
   isOrphaningDisconnect,
   type LiveKitFatalErrorDetail,
   type MembershipKey,
@@ -141,8 +142,7 @@ const BaseLiveKitRoom: React.FC<BaseLiveKitRoomProps> = ({
       },
     };
 
-    // eslint-disable-next-line no-param-reassign
-    room.options = { ...room.options, ...roomOptions };
+    applyRoomOptions(room, roomOptions);
     setOptionsApplied(true);
     setConnectOptions(opts);
   }, [room, roomOptions, iceServersLoading, iceServers, hasTurnServer, withAutoSubscribe]);

--- a/bigbluebutton-html5/imports/ui/components/livekit/base-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/base-room/component.tsx
@@ -18,6 +18,7 @@ import {
   applyLiveKitSdkLogLevel,
   installLiveKitSdkLogBridge,
 } from '/imports/ui/services/livekit/sdk-log-bridge';
+import { probeSubscriberNegotiation } from '/imports/ui/services/livekit/negotiation-probe';
 import connectionStatus from '/imports/ui/core/graphql/singletons/connectionStatus';
 import { useIceServers } from '/imports/ui/components/livekit/hooks';
 import shouldForceRelay from '/imports/ui/components/livekit/utils';
@@ -44,6 +45,8 @@ interface BaseLiveKitRoomProps {
   video?: boolean;
   withAutoSubscribe?: boolean;
   reconnectOnFatalFailures?: boolean;
+  // Instrumentation to track subscriber offers the server sends this room. Off by default.
+  probeNegotiation?: boolean;
   logPrefix: string;
   maxConnAttempts?: number;
   // Invoked once when reconnect attempts are exhausted (connAttempts reaches
@@ -75,6 +78,7 @@ const BaseLiveKitRoom: React.FC<BaseLiveKitRoomProps> = ({
   video = false,
   withAutoSubscribe = true,
   reconnectOnFatalFailures = true,
+  probeNegotiation = false,
   logPrefix,
   maxConnAttempts = DEFAULT_MAX_CONN_ATTEMPTS,
   onReconnectExhausted,
@@ -203,6 +207,20 @@ const BaseLiveKitRoom: React.FC<BaseLiveKitRoomProps> = ({
 
     installLiveKitSdkLogBridge();
   }, [sdkLogBridge]);
+
+  // Reactivate the negotiation probe on a reconnection/room re-creation
+  useEffect(() => {
+    if (!probeNegotiation) return undefined;
+
+    const probe = () => probeSubscriberNegotiation(room, logPrefix);
+
+    probe();
+    room.on(RoomEvent.SignalConnected, probe);
+
+    return () => {
+      room.off(RoomEvent.SignalConnected, probe);
+    };
+  }, [room, logPrefix, probeNegotiation]);
 
   useEffect(() => {
     if (logLevel !== undefined) applyLiveKitSdkLogLevel(logLevel);

--- a/bigbluebutton-html5/imports/ui/components/livekit/base-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/base-room/component.tsx
@@ -9,12 +9,15 @@ import {
   DisconnectReason,
   LogLevel,
   RoomEvent,
-  setLogLevel,
   type Room,
   type InternalRoomOptions,
   type RoomConnectOptions,
 } from 'livekit-client';
 import logger from '/imports/startup/client/logger';
+import {
+  applyLiveKitSdkLogLevel,
+  installLiveKitSdkLogBridge,
+} from '/imports/ui/services/livekit/sdk-log-bridge';
 import connectionStatus from '/imports/ui/core/graphql/singletons/connectionStatus';
 import { useIceServers } from '/imports/ui/components/livekit/hooks';
 import shouldForceRelay from '/imports/ui/components/livekit/utils';
@@ -36,6 +39,7 @@ interface BaseLiveKitRoomProps {
   bbbSessionToken: string;
   roomOptions: Partial<InternalRoomOptions>;
   logLevel?: LogLevel;
+  sdkLogBridge?: boolean;
   audio?: boolean;
   video?: boolean;
   withAutoSubscribe?: boolean;
@@ -66,6 +70,7 @@ const BaseLiveKitRoom: React.FC<BaseLiveKitRoomProps> = ({
   bbbSessionToken,
   roomOptions,
   logLevel,
+  sdkLogBridge = true,
   audio = false,
   video = false,
   withAutoSubscribe = true,
@@ -194,7 +199,13 @@ const BaseLiveKitRoom: React.FC<BaseLiveKitRoomProps> = ({
   }, [room, url, logPrefix, membershipKey]);
 
   useEffect(() => {
-    if (logLevel !== undefined) setLogLevel(logLevel);
+    if (!sdkLogBridge) return;
+
+    installLiveKitSdkLogBridge();
+  }, [sdkLogBridge]);
+
+  useEffect(() => {
+    if (logLevel !== undefined) applyLiveKitSdkLogLevel(logLevel);
   }, [logLevel]);
 
   useEffect(() => {

--- a/bigbluebutton-html5/imports/ui/components/livekit/base-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/base-room/component.tsx
@@ -51,6 +51,8 @@ interface BaseLiveKitRoomProps {
 }
 
 const DEFAULT_MAX_CONN_ATTEMPTS = 10;
+const RECONNECT_BASE_DELAY_MS = 1000;
+const RECONNECT_MAX_DELAY_MS = 8000;
 
 const BaseLiveKitRoom: React.FC<BaseLiveKitRoomProps> = ({
   membershipKey,
@@ -84,6 +86,8 @@ const BaseLiveKitRoom: React.FC<BaseLiveKitRoomProps> = ({
   } = useIceServers(bbbSessionToken);
   const isReconnectingRef = useRef(false);
   const reconnectExhaustedRef = useRef(false);
+  const connAttemptsRef = useRef(0);
+  const retryPendingRef = useRef(false);
 
   const onDisconnected = useCallback((reason?: DisconnectReason) => {
     logger.warn({
@@ -92,7 +96,7 @@ const BaseLiveKitRoom: React.FC<BaseLiveKitRoomProps> = ({
         reason,
         url,
         iceServers,
-        connAttempts,
+        connAttempts: connAttemptsRef.current,
         membershipKey,
       },
     }, `${logPrefix}: room disconnected, reason=${reason}`);
@@ -105,12 +109,15 @@ const BaseLiveKitRoom: React.FC<BaseLiveKitRoomProps> = ({
       return;
     }
 
+    if (retryPendingRef.current) return;
+
     // The SDK emits no error for a disconnect it will not retry, so the retry
     // effect has nothing to act on; a room whose owner keeps it (the primary)
     // is reconnected through that effect, so trigger it here
+    retryPendingRef.current = true;
     setConnError(new ForcedReconnectionError(`Terminal disconnect (reason=${reason})`));
     setConnAttempts((p) => p + 1);
-  }, [logPrefix, url, iceServers, connAttempts, membershipKey, onTerminalDisconnect]);
+  }, [logPrefix, url, iceServers, membershipKey, onTerminalDisconnect]);
 
   const onError = useCallback((error: Error) => {
     logger.error({
@@ -121,18 +128,27 @@ const BaseLiveKitRoom: React.FC<BaseLiveKitRoomProps> = ({
         errorName: error.name,
         errorStack: error.stack,
         url,
-        connAttempts,
+        connAttempts: connAttemptsRef.current,
       },
     }, `${logPrefix}: room error: ${error.message}`);
+
+    if (retryPendingRef.current) return;
+
+    retryPendingRef.current = true;
     setConnError(error);
     setConnAttempts((p) => p + 1);
-  }, [logPrefix, url, connAttempts, membershipKey]);
+  }, [logPrefix, url, membershipKey]);
+
+  useEffect(() => {
+    connAttemptsRef.current = connAttempts;
+  }, [connAttempts]);
 
   const onConnected = useCallback(() => {
     logger.info({
       logCode: `${logPrefix}_connected`,
       extraInfo: { membershipKey, url },
     }, `${logPrefix}: connected`);
+    retryPendingRef.current = false;
     setConnAttempts(0);
     setConnError(null);
   }, [logPrefix, url, membershipKey]);
@@ -192,29 +208,39 @@ const BaseLiveKitRoom: React.FC<BaseLiveKitRoomProps> = ({
       || iceServersLoading
       || !connError
       || connAttempts >= maxConnAttempts) {
-      return;
+      return undefined;
     }
 
     if (!(connError instanceof ConnectionError) && !(connError instanceof ForcedReconnectionError)) {
+      retryPendingRef.current = false;
       setConnError(null);
       setConnAttempts(0);
 
-      return;
+      return undefined;
     }
 
-    setConnError(null);
-    room.connect(url, token, connectOptions).catch((error: Error) => {
-      logger.debug({
-        logCode: `${logPrefix}_connect_retry_error`,
-        extraInfo: {
-          membershipKey,
-          connAttempts,
-          url,
-          errorMessage: error?.message,
-          errorStack: error?.stack,
-        },
-      }, `${logPrefix}: retry connect failed: ${(error)?.message}`);
-    });
+    const delay = Math.min(
+      RECONNECT_BASE_DELAY_MS * (2 ** Math.max(0, connAttempts - 1)),
+      RECONNECT_MAX_DELAY_MS,
+    );
+    const timer = setTimeout(() => {
+      setConnError(null);
+      retryPendingRef.current = false;
+      room.connect(url, token, connectOptions).catch((error: Error) => {
+        logger.debug({
+          logCode: `${logPrefix}_connect_retry_error`,
+          extraInfo: {
+            membershipKey,
+            connAttempts,
+            url,
+            errorMessage: error?.message,
+            errorStack: error?.stack,
+          },
+        }, `${logPrefix}: retry connect failed: ${(error)?.message}`);
+      });
+    }, delay);
+
+    return () => clearTimeout(timer);
   }, [
     room,
     token,

--- a/bigbluebutton-html5/imports/ui/components/livekit/base-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/base-room/component.tsx
@@ -5,8 +5,10 @@ import { useReactiveVar } from '@apollo/client';
 import { LiveKitRoom } from '@livekit/components-react';
 import {
   ConnectionError,
+  ConnectionState,
   DisconnectReason,
   LogLevel,
+  RoomEvent,
   setLogLevel,
   type Room,
   type InternalRoomOptions,
@@ -21,6 +23,7 @@ import {
   LK_FATAL_ERROR_EVENT,
   applyRoomOptions,
   isOrphaningDisconnect,
+  isReconnectingState,
   type LiveKitFatalErrorDetail,
   type MembershipKey,
 } from '/imports/ui/services/livekit';
@@ -53,6 +56,7 @@ interface BaseLiveKitRoomProps {
 const DEFAULT_MAX_CONN_ATTEMPTS = 10;
 const RECONNECT_BASE_DELAY_MS = 1000;
 const RECONNECT_MAX_DELAY_MS = 8000;
+const RECONNECT_STALL_TIMEOUT_MS = 60000;
 
 const BaseLiveKitRoom: React.FC<BaseLiveKitRoomProps> = ({
   membershipKey,
@@ -255,6 +259,56 @@ const BaseLiveKitRoom: React.FC<BaseLiveKitRoomProps> = ({
     logPrefix,
     membershipKey,
   ]);
+
+  // This effect is a last resort to detect a stalled reconnect attempt.
+  // If it isn't recovered and the signal is stuck, force a disconnect
+  // and log accordingly. This stems from actual production observations and is
+  // an attempting at tracking/fixing these stalls.
+  useEffect(() => {
+    let stallTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const forceReconnect = () => {
+      stallTimer = undefined;
+
+      if (isReconnectingRef.current) return;
+
+      isReconnectingRef.current = true;
+      retryPendingRef.current = true;
+      logger.warn({
+        logCode: `${logPrefix}_reconnect_stalled`,
+        extraInfo: {
+          membershipKey, url, connAttempts: connAttemptsRef.current, state: room.state,
+        },
+      }, `${logPrefix}: room stalled, forcing a reconnect`);
+
+      room.disconnect(false).catch(() => {}).then(() => {
+        setConnError(new ForcedReconnectionError(`Reconnect stalled (state=${room.state})`));
+        setConnAttempts((p) => p + 1);
+        isReconnectingRef.current = false;
+      });
+    };
+
+    const dispatchStallTimer = (state: ConnectionState) => {
+      if (isReconnectingState(state)) {
+        if (!stallTimer) stallTimer = setTimeout(forceReconnect, RECONNECT_STALL_TIMEOUT_MS);
+
+        return;
+      }
+
+      if (stallTimer) clearTimeout(stallTimer);
+
+      stallTimer = undefined;
+    };
+
+    room.on(RoomEvent.ConnectionStateChanged, dispatchStallTimer);
+    dispatchStallTimer(room.state);
+
+    return () => {
+      if (stallTimer) clearTimeout(stallTimer);
+
+      room.off(RoomEvent.ConnectionStateChanged, dispatchStallTimer);
+    };
+  }, [room, logPrefix, membershipKey, url]);
 
   // Reconnection tracking
   useEffect(() => {

--- a/bigbluebutton-html5/imports/ui/components/livekit/primary-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/primary-room/component.tsx
@@ -1,5 +1,7 @@
 /* eslint no-underscore-dangle: 0 */
-import React, { useCallback, useEffect, useState } from 'react';
+import React, {
+  useCallback, useEffect, useState, useMemo,
+} from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useMutation, useReactiveVar } from '@apollo/client';
 import {
@@ -23,7 +25,7 @@ import useMeeting from '/imports/ui/core/hooks/useMeeting';
 import useMeetingSettings from '/imports/ui/core/local-states/useMeetingSettings';
 import {
   liveKitRoomRegistry,
-  DEFAULT_ROOM_OPTIONS,
+  resolveRoomOptions,
   PRIMARY_KEY,
 } from '/imports/ui/services/livekit';
 import {
@@ -120,7 +122,9 @@ const PrimaryLiveKitRoom: React.FC<PrimaryLiveKitRoomProps> = ({ membership }) =
   const url = meetingSettings.public.media?.livekit?.url ?? `wss://${window.location.hostname}/livekit`;
   const withSelectiveSubscription = meetingSettings.public.media?.livekit?.selectiveSubscription?.enabled ?? true;
   const logLevel = meetingSettings.public.media?.livekit?.logLevel ?? LogLevel.warn;
-  const roomOptions = meetingSettings.public.media?.livekit?.roomOptions ?? DEFAULT_ROOM_OPTIONS;
+  const configuredRoomOptions = meetingSettings.public.media?.livekit?.roomOptions;
+  // A fresh object per render would re-run the room-options effect downstream.
+  const roomOptions = useMemo(() => resolveRoomOptions(configuredRoomOptions), [configuredRoomOptions]);
   const reconnectOnFatalFailures = meetingSettings.public.media?.livekit?.reconnectOnFatalFailures ?? true;
   const speakerLevel = useSpeakerLevel();
   const { data: bridges } = useMeeting((m) => ({

--- a/bigbluebutton-html5/imports/ui/components/livekit/primary-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/primary-room/component.tsx
@@ -201,6 +201,7 @@ const PrimaryLiveKitRoom: React.FC<PrimaryLiveKitRoomProps> = ({ membership }) =
   // A fresh object per render would re-run the room-options effect downstream.
   const roomOptions = useMemo(() => resolveRoomOptions(configuredRoomOptions), [configuredRoomOptions]);
   const reconnectOnFatalFailures = meetingSettings.public.media?.livekit?.reconnectOnFatalFailures ?? true;
+  const sdkLogBridge = meetingSettings.public.media?.livekit?.sdkLogBridge ?? true;
   const speakerLevel = useSpeakerLevel();
   const { data: bridges } = useMeeting((m) => ({
     cameraBridge: m.cameraBridge,
@@ -256,6 +257,7 @@ const PrimaryLiveKitRoom: React.FC<PrimaryLiveKitRoomProps> = ({ membership }) =
       bbbSessionToken={sessionToken}
       roomOptions={roomOptions}
       logLevel={logLevel}
+      sdkLogBridge={sdkLogBridge}
       audio={false}
       video={false}
       withAutoSubscribe={!withSelectiveSubscription}

--- a/bigbluebutton-html5/imports/ui/components/livekit/primary-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/primary-room/component.tsx
@@ -1,6 +1,6 @@
 /* eslint no-underscore-dangle: 0 */
 import React, {
-  useCallback, useEffect, useState, useMemo,
+  useCallback, useEffect, useRef, useState, useMemo,
 } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useMutation, useReactiveVar } from '@apollo/client';
@@ -14,6 +14,7 @@ import {
 } from '@livekit/components-react';
 import {
   ConnectionQuality,
+  ConnectionState,
   LogLevel,
   RoomEvent,
   type Room,
@@ -50,6 +51,8 @@ const intlMessages = defineMessages({
   },
 });
 
+const TALKING_CLEAR_GRACE_MS = 500;
+
 interface PrimaryLiveKitRoomProps {
   membership: LiveKitRoomRow;
 }
@@ -79,11 +82,34 @@ const PrimaryObserver: React.FC<PrimaryObserverProps> = ({ room, url, usingAudio
     }, `LK primary: ${connectionState}`);
   }, [connectionState, url]);
 
+  const isRoomConnected = connectionState === ConnectionState.Connected;
+  const speakingIsFrozen = useRef(false);
+
   useEffect(() => {
-    if (!usingAudio) return;
+    if (!usingAudio) return undefined;
+
+    if (!isRoomConnected) {
+      speakingIsFrozen.current = true;
+      // Cleanup the talking state after a grace period if LiveKit disconnected.
+      // This happens server-side on a longer timeout as well; also do it here, on
+      // a faster grace period, to clean up the state quicker whenever possible.
+      const timer = setTimeout(() => {
+        setUserTalking({ variables: { talking: false } });
+      }, TALKING_CLEAR_GRACE_MS);
+
+      return () => clearTimeout(timer);
+    }
+
+    if (speakingIsFrozen.current) {
+      if (isSpeaking) return undefined;
+
+      speakingIsFrozen.current = false;
+    }
 
     setUserTalking({ variables: { talking: isSpeaking } });
-  }, [isSpeaking, isMuted, usingAudio]);
+
+    return undefined;
+  }, [isSpeaking, isMuted, usingAudio, isRoomConnected]);
 
   useEffect(() => {
     if (!usingAudio) return;

--- a/bigbluebutton-html5/imports/ui/components/livekit/primary-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/primary-room/component.tsx
@@ -201,6 +201,7 @@ const PrimaryLiveKitRoom: React.FC<PrimaryLiveKitRoomProps> = ({ membership }) =
   // A fresh object per render would re-run the room-options effect downstream.
   const roomOptions = useMemo(() => resolveRoomOptions(configuredRoomOptions), [configuredRoomOptions]);
   const reconnectOnFatalFailures = meetingSettings.public.media?.livekit?.reconnectOnFatalFailures ?? true;
+  const probeNegotiation = meetingSettings.public.media?.livekit?.negotiationProbe ?? false;
   const sdkLogBridge = meetingSettings.public.media?.livekit?.sdkLogBridge ?? true;
   const speakerLevel = useSpeakerLevel();
   const { data: bridges } = useMeeting((m) => ({
@@ -262,6 +263,7 @@ const PrimaryLiveKitRoom: React.FC<PrimaryLiveKitRoomProps> = ({ membership }) =
       video={false}
       withAutoSubscribe={!withSelectiveSubscription}
       reconnectOnFatalFailures={reconnectOnFatalFailures}
+      probeNegotiation={probeNegotiation}
       logPrefix="livekit_primary"
       onFatalReconnect={onFatalReconnect}
       onReconnectExhausted={onReconnectExhausted}

--- a/bigbluebutton-html5/imports/ui/components/livekit/primary-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/primary-room/component.tsx
@@ -49,6 +49,10 @@ const intlMessages = defineMessages({
     id: 'app.media.mediaReconnecting',
     description: 'Media reconnection in progress toast message',
   },
+  mediaReconnectFailed: {
+    id: 'app.media.mediaReconnectFailed',
+    description: 'Media reconnection gave up toast message',
+  },
 });
 
 const TALKING_CLEAR_GRACE_MS = 500;
@@ -177,6 +181,18 @@ const PrimaryLiveKitRoom: React.FC<PrimaryLiveKitRoomProps> = ({ membership }) =
     notify(intl.formatMessage(intlMessages.mediaReconnecting), 'warning', 'warning');
   }, [intl]);
 
+  const onReconnectExhausted = useCallback(() => {
+    // Nothing retries reconnecting the primary room after this, so keep
+    // the toast open (autoClose: false) to make it clear for the user that
+    // we reached a dead end.
+    notify(
+      intl.formatMessage(intlMessages.mediaReconnectFailed),
+      'error',
+      'warning',
+      { autoClose: false },
+    );
+  }, [intl]);
+
   const { sessionToken } = Auth;
   if (!membership.token || typeof sessionToken !== 'string') return null;
 
@@ -195,6 +211,7 @@ const PrimaryLiveKitRoom: React.FC<PrimaryLiveKitRoomProps> = ({ membership }) =
       reconnectOnFatalFailures={reconnectOnFatalFailures}
       logPrefix="livekit_primary"
       onFatalReconnect={onFatalReconnect}
+      onReconnectExhausted={onReconnectExhausted}
     >
       <PrimaryObserver room={room} url={url} usingAudio={usingAudio} />
       {withAudioPlayback && (!hasActiveSecondary || !canPlayAudio) && <LKAutoplayModalContainer />}

--- a/bigbluebutton-html5/imports/ui/components/livekit/primary-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/primary-room/component.tsx
@@ -3,6 +3,7 @@ import React, {
   useCallback, useEffect, useRef, useState, useMemo,
 } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
+import { toast } from 'react-toastify';
 import { useMutation, useReactiveVar } from '@apollo/client';
 import {
   RoomAudioRenderer,
@@ -27,6 +28,7 @@ import useMeetingSettings from '/imports/ui/core/local-states/useMeetingSettings
 import {
   liveKitRoomRegistry,
   resolveRoomOptions,
+  hasConnectedOnce,
   PRIMARY_KEY,
 } from '/imports/ui/services/livekit';
 import {
@@ -56,6 +58,9 @@ const intlMessages = defineMessages({
 });
 
 const TALKING_CLEAR_GRACE_MS = 500;
+const MEDIA_INTERRUPTED_NOTICE_GRACE_MS = 1000;
+const SIGNAL_RESUME_NOTICE_GRACE_MS = 5000;
+const MEDIA_RECONNECT_TOAST_ID = 'livekit-media-reconnecting';
 
 interface PrimaryLiveKitRoomProps {
   membership: LiveKitRoomRow;
@@ -68,11 +73,13 @@ interface PrimaryObserverProps {
 }
 
 const PrimaryObserver: React.FC<PrimaryObserverProps> = ({ room, url, usingAudio }) => {
+  const intl = useIntl();
   const { localParticipant } = useLocalParticipant();
   const [setUserTalking] = useMutation(USER_SET_TALKING);
   const [setUserDeafened] = useMutation(USER_SET_DEAFENED);
   const isSpeaking = useIsSpeaking(localParticipant);
   const connectionState = useConnectionState(room);
+  const hasActiveSecondary = useHasActiveNonPrimaryMembership();
   const { quality } = useConnectionQualityIndicator({ participant: localParticipant });
   // @ts-ignore
   const isMuted = useReactiveVar(AudioManager._isMuted.value) as boolean;
@@ -114,6 +121,44 @@ const PrimaryObserver: React.FC<PrimaryObserverProps> = ({ room, url, usingAudio
 
     return undefined;
   }, [isSpeaking, isMuted, usingAudio, isRoomConnected]);
+
+  const isMediaInterrupted = hasConnectedOnce(room) && connectionState !== ConnectionState.Connected;
+  const isResuming = connectionState === ConnectionState.SignalReconnecting;
+
+  useEffect(() => {
+    if (!isMediaInterrupted) {
+      toast.dismiss(MEDIA_RECONNECT_TOAST_ID);
+
+      return undefined;
+    }
+
+    const timer = setTimeout(() => {
+      notify(
+        intl.formatMessage(intlMessages.mediaReconnecting),
+        'warning',
+        'warning',
+        { autoClose: false, toastId: MEDIA_RECONNECT_TOAST_ID },
+      );
+    }, isResuming ? SIGNAL_RESUME_NOTICE_GRACE_MS : MEDIA_INTERRUPTED_NOTICE_GRACE_MS);
+
+    return () => clearTimeout(timer);
+  }, [isMediaInterrupted, isResuming, intl]);
+
+  // Propagate reconnection states to AudioManager
+  useEffect(() => {
+    if (!usingAudio) return undefined;
+
+    // @ts-ignore - AudioManager.bridge is any of the audio bridges
+    const micRoomKey = AudioManager.bridge?.micRoomKey;
+    // AudioManager is only concerned with the primary room's microphone for now.
+    const ownsMic = micRoomKey === undefined || micRoomKey === PRIMARY_KEY;
+
+    AudioManager.isReconnecting = ownsMic && isMediaInterrupted && !isResuming;
+
+    return undefined;
+  }, [isMediaInterrupted, isResuming, usingAudio, hasActiveSecondary]);
+
+  useEffect(() => () => toast.dismiss(MEDIA_RECONNECT_TOAST_ID), []);
 
   useEffect(() => {
     if (!usingAudio) return;
@@ -178,10 +223,16 @@ const PrimaryLiveKitRoom: React.FC<PrimaryLiveKitRoomProps> = ({ membership }) =
   }, []);
 
   const onFatalReconnect = useCallback(() => {
-    notify(intl.formatMessage(intlMessages.mediaReconnecting), 'warning', 'warning');
+    notify(
+      intl.formatMessage(intlMessages.mediaReconnecting),
+      'warning',
+      'warning',
+      { autoClose: false, toastId: MEDIA_RECONNECT_TOAST_ID },
+    );
   }, [intl]);
 
   const onReconnectExhausted = useCallback(() => {
+    toast.dismiss(MEDIA_RECONNECT_TOAST_ID);
     // Nothing retries reconnecting the primary room after this, so keep
     // the toast open (autoClose: false) to make it clear for the user that
     // we reached a dead end.

--- a/bigbluebutton-html5/imports/ui/components/livekit/secondary-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/secondary-room/component.tsx
@@ -1,11 +1,13 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+  useEffect, useRef, useState, useMemo,
+} from 'react';
 import { LogLevel, type Room } from 'livekit-client';
 import { RoomAudioRenderer } from '@livekit/components-react';
 import Auth from '/imports/ui/services/auth';
 import useMeetingSettings from '/imports/ui/core/local-states/useMeetingSettings';
 import {
   liveKitRoomRegistry,
-  DEFAULT_ROOM_OPTIONS,
+  resolveRoomOptions,
   type MembershipKey,
 } from '/imports/ui/services/livekit';
 import BaseLiveKitRoom from '/imports/ui/components/livekit/base-room/component';
@@ -53,7 +55,9 @@ const SecondaryLiveKitRoom: React.FC<SecondaryLiveKitRoomProps> = ({
   const speakerLevel = useSpeakerLevel();
   const url = meetingSettings.public.media?.livekit?.url ?? `wss://${window.location.hostname}/livekit`;
   const logLevel = meetingSettings.public.media?.livekit?.logLevel ?? LogLevel.warn;
-  const roomOptions = meetingSettings.public.media?.livekit?.roomOptions ?? DEFAULT_ROOM_OPTIONS;
+  const configuredRoomOptions = meetingSettings.public.media?.livekit?.roomOptions;
+  // A fresh object per render would re-run the room-options effect downstream.
+  const roomOptions = useMemo(() => resolveRoomOptions(configuredRoomOptions), [configuredRoomOptions]);
   const reconnectOnFatalFailures = meetingSettings.public.media?.livekit?.reconnectOnFatalFailures ?? true;
 
   const key: MembershipKey = membershipKey ?? `${membership.purpose}:${membership.roomName}`;

--- a/bigbluebutton-html5/imports/ui/components/livekit/secondary-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/livekit/secondary-room/component.tsx
@@ -55,6 +55,7 @@ const SecondaryLiveKitRoom: React.FC<SecondaryLiveKitRoomProps> = ({
   const speakerLevel = useSpeakerLevel();
   const url = meetingSettings.public.media?.livekit?.url ?? `wss://${window.location.hostname}/livekit`;
   const logLevel = meetingSettings.public.media?.livekit?.logLevel ?? LogLevel.warn;
+  const sdkLogBridge = meetingSettings.public.media?.livekit?.sdkLogBridge ?? true;
   const configuredRoomOptions = meetingSettings.public.media?.livekit?.roomOptions;
   // A fresh object per render would re-run the room-options effect downstream.
   const roomOptions = useMemo(() => resolveRoomOptions(configuredRoomOptions), [configuredRoomOptions]);
@@ -108,6 +109,7 @@ const SecondaryLiveKitRoom: React.FC<SecondaryLiveKitRoomProps> = ({
       bbbSessionToken={sessionToken}
       roomOptions={roomOptions}
       logLevel={logLevel}
+      sdkLogBridge={sdkLogBridge}
       audio={false}
       video={false}
       withAutoSubscribe

--- a/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/notifications/component.tsx
@@ -5,6 +5,7 @@ import useCurrentUser from '../../core/hooks/useCurrentUser';
 import { notify } from '../../services/notification';
 import {
   NotifyPublishedPoll,
+  cameraEjected,
   layoutUpdate,
   pendingGuestAlert,
   userJoinPushAlert,
@@ -40,6 +41,8 @@ const Notifications: React.FC = () => {
         'app.notification.userJoinPushAlert': userJoinPushAlert,
         'app.notification.userLeavePushAlert': userLeavePushAlert,
         'app.layoutUpdate.label': layoutUpdate,
+        'app.video.ejectedByModerator': cameraEjected,
+        'app.video.ejectedByLockSettings': cameraEjected,
       });
 
   const {

--- a/bigbluebutton-html5/imports/ui/components/notifications/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/notifications/service.ts
@@ -1,5 +1,6 @@
 import { makeVar } from '@apollo/client';
 import { Notification } from './queries';
+import { expectStreamStop } from '/imports/ui/components/video-provider/state';
 import { getSettingsSingletonInstance } from '/imports/ui/services/settings';
 import { throttle } from '/imports/utils/throttle';
 
@@ -123,4 +124,17 @@ export default {
   userJoinPushAlert,
   userLeavePushAlert,
   layoutUpdate,
+};
+
+export const cameraEjected = (
+  notification: Notification,
+  notifier: (notification: Notification) => void,
+) => {
+  const { streamId } = notification.messageValues;
+
+  if (streamId) expectStreamStop(streamId);
+
+  // There's one other notification for lock settings. It has its own notification handler,
+  // Notify on a case-by-case basis to avoid multiple annoying toasts.
+  if (notification.messageId === 'app.video.ejectedByModerator') notifier(notification);
 };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/hooks/index.ts
@@ -23,6 +23,7 @@ import {
   setVideoState,
   useConnectingStream,
   getVideoState,
+  expectStreamStop,
 } from '/imports/ui/components/video-provider/state';
 import {
   GRID_USERS_SUBSCRIPTION,
@@ -938,7 +939,7 @@ export const useExitVideo = (forceExit = false) => {
   const [cameraBroadcastStop] = useMutation(CAMERA_BROADCAST_STOP);
   const ownStreamsRef = useOwnStreamsRef();
 
-  const exitVideo = useCallback(async () => {
+  const exitVideo = useCallback(async (expected = true) => {
     const { isConnected } = getVideoState();
 
     if (isConnected || forceExit) {
@@ -946,7 +947,11 @@ export const useExitVideo = (forceExit = false) => {
         return cameraBroadcastStop({ variables: { cameraId } });
       };
 
-      const results = ownStreamsRef.current.map((streamId) => sendUserUnshareWebcam(streamId));
+      const results = ownStreamsRef.current.map((streamId) => {
+        if (expected) expectStreamStop(streamId);
+
+        return sendUserUnshareWebcam(streamId);
+      });
 
       return Promise.all(results).then(() => {
         videoService.exitedVideo();
@@ -993,13 +998,14 @@ export const useStopVideo = () => {
   const [cameraBroadcastStop] = useMutation(CAMERA_BROADCAST_STOP);
   const ownStreamsRef = useOwnStreamsRef();
 
-  return useCallback(async (cameraId?: string) => {
+  return useCallback(async (cameraId?: string, expected = true) => {
     const streams = ownStreamsRef.current;
     const connectingStream = getConnectingStream();
     const hasTargetStream = streams.some((streamId) => streamId === cameraId);
     const hasOtherStream = streams.some((streamId) => streamId !== cameraId);
 
-    if (hasTargetStream) {
+    if (hasTargetStream && cameraId) {
+      if (expected) expectStreamStop(cameraId);
       cameraBroadcastStop({ variables: { cameraId } });
     }
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
@@ -439,7 +439,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
       const stream = publication.trackName;
       bridgeRefs.current.remoteTracks[stream] = track;
       attachLiveKitStream(stream);
-      logger.debug({
+      logger.info({
         logCode: 'livekit_camera_subscribed',
         extraInfo: {
           cameraId: stream,
@@ -461,7 +461,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     bridgeRefs.current.subscriptions.delete(trackSid);
     const stream = publication?.trackName;
 
-    logger.debug({
+    logger.info({
       logCode: 'livekit_camera_unsubscribed',
       extraInfo: {
         cameraId: stream,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
@@ -325,8 +325,25 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     }
   };
 
+  const findRemoteCameraPublication = (stream: string): RemoteTrackPublication | undefined => {
+    let found: RemoteTrackPublication | undefined;
+
+    liveKitRoomRegistry.getPrimary()?.remoteParticipants.forEach((participant: RemoteParticipant) => {
+      participant.videoTrackPublications.forEach((publication: RemoteTrackPublication) => {
+        if (!found && lkIsCameraSource(publication) && publication.trackName === stream) found = publication;
+      });
+    });
+
+    return found;
+  };
+
   const subscribeToRemotePub = (stream: string) => {
-    const publication = bridgeRefs.current.publications.get(stream) as RemoteTrackPublication;
+    // Pull the remote publish fresh to avoid staleness during reconnects
+    const remotePub = findRemoteCameraPublication(stream);
+    const publication = remotePub
+      ?? (bridgeRefs.current.publications.get(stream) as RemoteTrackPublication | undefined);
+
+    if (remotePub) bridgeRefs.current.publications.set(stream, remotePub);
 
     // If a publication is not present yet, it will be added when we receive
     // the publish event from the server and this function will be called again
@@ -474,9 +491,11 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
   };
 
   const handleTrackPublished = useCallback((publication: RemoteTrackPublication) => {
-    const { trackName } = publication;
+    const { trackName, trackSid } = publication;
 
-    if (!lkIsCameraSource(publication) || bridgeRefs.current.publications.has(trackName)) return;
+    if (!lkIsCameraSource(publication)) return;
+    // A republished stream carries a new sid; let it replace the cached entry.
+    if (bridgeRefs.current.publications.get(trackName)?.trackSid === trackSid) return;
 
     bridgeRefs.current.publications.set(trackName, publication);
 

--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
@@ -135,6 +135,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     ],
   });
   const [meetingSettings] = useMeetingSettings();
+  const watchedRemoteTracks = useRef(new WeakSet<MediaStreamTrack>());
   const bridgeRefs = useRef<LiveKitCameraBridgeRefs>({
     remoteTracks: {},
     localTracks: {},
@@ -442,6 +443,36 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     }
   }, [handleLocalStreamInactive, handleStreamFailure, playStart]);
 
+  const watchRemoteTrackEnd = (mediaStreamTrack: MediaStreamTrack) => {
+    if (mediaStreamTrack == null) return;
+    if (watchedRemoteTracks.current.has(mediaStreamTrack)) return;
+
+    watchedRemoteTracks.current.add(mediaStreamTrack);
+
+    const onEnded = () => {
+      const carried = Object.entries(bridgeRefs.current.remoteTracks)
+        .find(([, track]) => track.mediaStreamTrack === mediaStreamTrack);
+
+      if (!carried) return;
+
+      const [stream, track] = carried;
+      logger.debug({
+        logCode: 'livekit_camera_track_ended',
+        extraInfo: { cameraId: stream, trackSid: track.sid },
+      }, `LiveKit: camera track ended - ${track.sid}`);
+
+      // Failed makes the camera container render the placeholder instead
+      notifyStreamStateChange(stream, 'failed');
+    };
+
+    if (mediaStreamTrack.readyState === 'ended') {
+      onEnded();
+      return;
+    }
+
+    mediaStreamTrack.addEventListener('ended', onEnded, { once: true });
+  };
+
   const handleTrackSubscribed = (
     track: RemoteTrack,
     publication: RemoteTrackPublication,
@@ -456,6 +487,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
       const stream = publication.trackName;
       bridgeRefs.current.remoteTracks[stream] = track;
       attachLiveKitStream(stream);
+      watchRemoteTrackEnd(track?.mediaStreamTrack);
       logger.info({
         logCode: 'livekit_camera_subscribed',
         extraInfo: {
@@ -486,6 +518,9 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
         trackSid: publication.trackSid,
       },
     }, `LiveKit: camera unsubscribed - ${trackSid}`);
+
+    // Failed makes the camera container render the placeholder instead
+    notifyStreamStateChange(stream, 'failed');
 
     delete bridgeRefs.current.remoteTracks[stream];
   };

--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
@@ -5,6 +5,7 @@ import React, {
   useMemo,
 } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
+import { toast } from 'react-toastify';
 import {
   type LocalTrack,
   type RemoteParticipant,
@@ -31,6 +32,11 @@ import {
   liveKitRoomRegistry,
 } from '/imports/ui/services/livekit';
 import useMeetingSettings from '/imports/ui/core/local-states/useMeetingSettings';
+import { notify } from '/imports/ui/services/notification';
+import {
+  expectStreamStop,
+  consumeExpectedStreamStop,
+} from '/imports/ui/components/video-provider/state';
 
 const intlClientErrors = defineMessages({
   permissionError: {
@@ -49,7 +55,13 @@ const intlClientErrors = defineMessages({
     id: 'app.video.inactiveError',
     description: 'Camera stopped unexpectedly',
   },
+  mediaTimedOutError: {
+    id: 'app.video.mediaTimedOutError',
+    description: 'Camera stream was interrupted',
+  },
 });
+
+const CAMERA_STOPPED_TOAST_ID = 'livekit-camera-stopped';
 
 const intlSFUErrors = defineMessages({
   2000: {
@@ -72,9 +84,9 @@ interface LiveKitCameraBridgeProps {
   currentVideoPageIndex: number;
   streams: VideoItem[];
   playStart: (cameraId: string) => void;
-  exitVideo: () => void;
+  exitVideo: (expected?: boolean) => void;
   lockUser: () => void;
-  stopVideo: (cameraId?: string) => void;
+  stopVideo: (cameraId?: string, expected?: boolean) => void;
   overflowCount: number;
   overflowUsers: GridItem[];
 }
@@ -138,6 +150,9 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
 
   const withSelectiveSubscription = meetingSettings.public.media?.livekit?.selectiveSubscription?.enabled ?? true;
 
+  // Streams whose failures were already surfaced to the end user. Avoids trailing toasts.
+  const announcedFailures = useRef(new Set<string>());
+
   const handleStreamFailure = useCallback((error: Error, stream: string, isLocal: boolean) => {
     const { name: errorName, message: errorMessage } = error;
     const errorLocale = intlClientErrors[errorName as keyof typeof intlClientErrors]
@@ -156,7 +171,10 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     }, `LiveKit: camera failure ${errorName} - ${errorMessage}`);
 
     if (isLocal) {
+      if (errorLocale) announcedFailures.current.add(stream);
+
       stopStream(stream, false);
+
       if (errorLocale) VideoService.notify(intl.formatMessage(errorLocale));
     } else {
       const stillExists = streamsRef.current.some(
@@ -188,7 +206,12 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
       extraInfo: { role, cameraId: stream, restarting },
     }, `LiveKit: camera stop requested. Role ${role}, restarting ${restarting}`);
 
-    if (isLocal) stopVideo(stream);
+    if (isLocal) {
+      if (restarting) expectStreamStop(stream);
+
+      stopVideo(stream, restarting);
+    }
+
     destroyStream(stream);
   }, [stopVideo]);
 
@@ -218,6 +241,23 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     }
 
     if (isLocal) {
+      const wasPublished = !!bridgeRefs.current.localTracks[stream];
+      const alreadyAnnounced = announcedFailures.current.delete(stream);
+
+      // Bubble up the unexpect camera stop to the end user
+      if (wasPublished && !alreadyAnnounced && !consumeExpectedStreamStop(stream)) {
+        logger.warn({
+          logCode: 'livekit_camera_stopped_unexpectedly',
+          extraInfo: { cameraId: stream },
+        }, 'LiveKit: camera stopped without the user asking');
+        notify(
+          intl.formatMessage(intlClientErrors.mediaTimedOutError),
+          'error',
+          'video',
+          { autoClose: false, toastId: CAMERA_STOPPED_TOAST_ID },
+        );
+      }
+
       const track = bridgeRefs.current.localTracks[stream];
       const localRoom = liveKitRoomRegistry.getPrimary();
       const { videoTrackPublications } = localRoom?.localParticipant ?? {};
@@ -366,6 +406,9 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
       }
 
       bridgeRefs.current.localTracks[stream] = publication.track;
+      consumeExpectedStreamStop(stream);
+      announcedFailures.current.delete(stream);
+      toast.dismiss(CAMERA_STOPPED_TOAST_ID);
       localBBBStream.on('streamSwapped', ({ newStream }: { oldStream: MediaStream, newStream: MediaStream }) => {
         if (newStream) replaceVideoTracks(stream, newStream);
       });
@@ -503,20 +546,21 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
 
   useEffect(() => {
     const evtRoom = liveKitRoomRegistry.getPrimary();
+    const handleBeforeUnload = () => exitVideo();
 
-    window.addEventListener('beforeunload', exitVideo);
+    window.addEventListener('beforeunload', handleBeforeUnload);
     evtRoom?.on(RoomEvent.TrackUnpublished, handleTrackUnpublished);
     evtRoom?.on(RoomEvent.TrackSubscribed, handleTrackSubscribed);
     evtRoom?.on(RoomEvent.TrackUnsubscribed, handleTrackUnsubscribed);
 
     return () => {
-      window.removeEventListener('beforeunload', exitVideo);
+      window.removeEventListener('beforeunload', handleBeforeUnload);
       evtRoom?.off(RoomEvent.TrackUnpublished, handleTrackUnpublished);
       evtRoom?.off(RoomEvent.TrackSubscribed, handleTrackSubscribed);
       evtRoom?.off(RoomEvent.TrackUnsubscribed, handleTrackUnsubscribed);
 
       VideoService.updatePeerDictionaryReference({});
-      exitVideo();
+      exitVideo(false);
       Object.keys(bridgeRefs.current.localTracks).forEach((stream) => {
         stopStream(stream, false);
       });

--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/component.tsx
@@ -269,7 +269,7 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
     if (isLocal) {
       const localStream = bridgeRefs.current.localVideoStreams[stream];
 
-      if (localStream) {
+      if (localStream?.mediaStream) {
         videoElement.pause();
         videoElement.srcObject = localStream.mediaStream;
         videoElement.load();
@@ -315,6 +315,9 @@ const LiveKitCameraBridge: React.FC<LiveKitCameraBridgeProps> = ({
 
     try {
       const localBBBStream = VideoService.getPreloadedStream();
+
+      if (!localBBBStream) throw new Error('LiveKit: no preloaded camera stream to publish');
+
       bridgeRefs.current.localVideoStreams[stream] = localBBBStream;
       const { mediaStream } = localBBBStream;
       const LIVEKIT_SETTINGS = meetingSettings.public.media.livekit?.camera;

--- a/bigbluebutton-html5/imports/ui/components/video-provider/state.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/state.ts
@@ -52,10 +52,21 @@ const setConnectingStream = (stream: ConnectingStream | null) => {
 
 const getConnectingStream = () => connectingStream();
 
+// Cameras this client asked to stop (ie not server-initiated)
+const expectedStreamStops = new Set<string>();
+
+const expectStreamStop = (stream: string) => {
+  expectedStreamStops.add(stream);
+};
+
+const consumeExpectedStreamStop = (stream: string) => expectedStreamStops.delete(stream);
+
 export {
   useVideoState,
   setVideoState,
   getVideoState,
+  expectStreamStop,
+  consumeExpectedStreamStop,
   useConnectingStream,
   getConnectingStream,
   setConnectingStream,

--- a/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/video-list/video-list-item/component.tsx
@@ -218,7 +218,15 @@ const VideoListItem: React.FC<VideoListItemProps> = (props) => {
     const newHealthState = !isStreamStateUnhealthy(streamState);
     e.stopPropagation();
     setIsStreamHealthy(newHealthState);
+    // A healthy report may be a fresh attach with nothing decoded yet (a new
+    // srcObject resets readyState); the element's events set the flag back
+    // when a frame lands.
+    if (newHealthState && videoTag.current) {
+      setVideoDataLoaded(videoTag.current.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA);
+    }
   };
+
+  const onCanPlay = () => setVideoDataLoaded(true);
 
   const onLoadedData = () => {
     setVideoDataLoaded(true);
@@ -239,6 +247,7 @@ const VideoListItem: React.FC<VideoListItemProps> = (props) => {
       subscribeToStreamStateChange(cameraId, onStreamStateChange);
       onVideoItemMount(videoTag.current!);
       videoTag?.current?.addEventListener('loadeddata', onLoadedData);
+      videoTag?.current?.addEventListener('canplay', onCanPlay);
     }
 
     if (videoContainer.current) {
@@ -249,6 +258,7 @@ const VideoListItem: React.FC<VideoListItemProps> = (props) => {
     return () => {
       if (!isAudioOnly) {
         videoTag?.current?.removeEventListener('loadeddata', onLoadedData);
+        videoTag?.current?.removeEventListener('canplay', onCanPlay);
       }
       pluginSqueezedResizeObserver.disconnect();
       resizeObserver.disconnect();

--- a/bigbluebutton-html5/imports/ui/core/adapters/voice-activity.tsx
+++ b/bigbluebutton-html5/imports/ui/core/adapters/voice-activity.tsx
@@ -18,6 +18,7 @@ import {
   useTalkingUserConsumersCount,
 } from '/imports/ui/core/hooks/useTalkingUsers';
 import ConnectionStatus from '/imports/ui/core/graphql/singletons/connectionStatus';
+import Auth from '/imports/ui/services/auth';
 
 const VoiceActivityAdapter = () => {
   const shouldUseLiveKitAudioState = useShouldUseLiveKitAudioState();
@@ -49,11 +50,15 @@ const VoiceActivityAdapter = () => {
     // LiveKit state should be resilient to GraphQL disconnections on certain
     // occasions. Complete absence of data from either sources is treated in
     // the LK hooks.
-    if (!connected && !shouldUseLiveKitAudioState) {
-      dispatchWhoIsUnmutedUpdate(undefined);
-      dispatchWhoIsTalkingUpdate(undefined);
-      dispatchTalkingUserUpdate(undefined);
-    }
+    if (connected || shouldUseLiveKitAudioState) return;
+
+    // Everyone but the local user is dropped and rebuilt from the unmuted set
+    // on disconnections. The local entry stays because an absent one reads as
+    // muted, and that causes a local state inconsistency where the microphone
+    // might actually be unmuted/transmitting, but the UI shows it as muted.
+    dispatchWhoIsUnmutedUpdate(undefined, [Auth.userID as string]);
+    dispatchWhoIsTalkingUpdate(undefined);
+    dispatchTalkingUserUpdate(undefined);
   }, [connected, shouldUseLiveKitAudioState]);
 
   return null;

--- a/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsUnmutedGraphql.ts
+++ b/bigbluebutton-html5/imports/ui/core/hooks/useWhoIsUnmutedGraphql.ts
@@ -19,9 +19,21 @@ const createUseWhoIsUnmutedGraphql = () => {
     setState,
   } = createReactiveRecordStateHook();
 
-  const dispatchWhoIsUnmutedUpdate = (data?: { userId: string; muted: boolean }[]) => {
+  // `retain` survives a reset: the stream replays only talking-or-unmuted users,
+  // so anyone it omits has to be dropped here or they stay unmuted forever.
+  const dispatchWhoIsUnmutedUpdate = (
+    data?: { userId: string; muted: boolean }[],
+    retain: string[] = [],
+  ) => {
     if (!data) {
-      setState({});
+      const currentUnmuted = getState();
+      const kept: Record<string, boolean> = {};
+
+      retain.forEach((userId) => {
+        if (currentUnmuted[userId]) kept[userId] = true;
+      });
+      setState(kept);
+
       return;
     }
 

--- a/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
+++ b/bigbluebutton-html5/imports/ui/services/audio-manager/index.js
@@ -676,10 +676,14 @@ class AudioManager {
 
     let newMuteState;
 
-    // when user leaves voice conf, set muted = false
-    // as the user might have been transfered to a breakout room
+    // On the FreeSWITCH bridge a voice-conf leave means a transfer may be under
+    // way, so the user is unmuted. Under LiveKit it can only be a reconnect or a
+    // disconnect, and the event carries no observed voice state at all: akka
+    // builds it from an empty voice user, whose mute field is a hard-coded
+    // placeholder. Neither half of it says anything about this user, so the
+    // whole event is ignored rather than just its unmute.
     if (leftVoiceConf !== undefined && leftVoiceConf) {
-      newMuteState = false;
+      if (!this.isUsingLiveKit) newMuteState = false;
     } else if (muted !== undefined && muted !== this.isMuted) {
       newMuteState = muted;
     }

--- a/bigbluebutton-html5/imports/ui/services/livekit/index.ts
+++ b/bigbluebutton-html5/imports/ui/services/livekit/index.ts
@@ -84,10 +84,14 @@ export const waitForRoomConnection = (
       return;
     }
 
-    // A room torn down before the wait started gets no further events either.
-    // A room that has simply not connected yet reports the same state, so only
-    // abort for one that has been connected before.
-    if (room.state === ConnectionState.Disconnected && hasConnectedOnce(room)) {
+    // A secondary room torn down before the wait started gets no further
+    // events: its membership is gone and a new one gets a new Room. A room
+    // that has simply not connected yet reports the same state, so only abort
+    // for one that has been connected before. The primary is durable: it is
+    // reconnected by the next membership mount, so it is waited for instead.
+    if (room.state === ConnectionState.Disconnected
+      && hasConnectedOnce(room)
+      && !liveKitRoomRegistry.isPrimary(room)) {
       reject(new Error('Room already disconnected'));
 
       return;

--- a/bigbluebutton-html5/imports/ui/services/livekit/index.ts
+++ b/bigbluebutton-html5/imports/ui/services/livekit/index.ts
@@ -3,7 +3,6 @@ import {
   DisconnectReason,
   RoomEvent,
   Track,
-  type InternalRoomOptions,
   type Room,
   type LocalTrackPublication,
   type TrackPublication,
@@ -27,12 +26,6 @@ const NON_ORPHANING_DISCONNECT_REASONS: DisconnectReason[] = [
 
 export const isOrphaningDisconnect = (reason?: DisconnectReason): boolean => {
   return reason === undefined || !NON_ORPHANING_DISCONNECT_REASONS.includes(reason);
-};
-
-export const DEFAULT_ROOM_OPTIONS: Partial<InternalRoomOptions> = {
-  adaptiveStream: true,
-  dynacast: true,
-  stopLocalTrackOnUnpublish: false,
 };
 
 export interface LiveKitFatalErrorDetail {
@@ -163,6 +156,9 @@ export const lkToggleMuteCameras = (mute: boolean): void => {
 
 export {
   liveKitRoomRegistry,
+  applyRoomOptions,
+  resolveRoomOptions,
+  DEFAULT_ROOM_OPTIONS,
   PRIMARY_KEY,
   breakoutListenKey,
 } from './registry';

--- a/bigbluebutton-html5/imports/ui/services/livekit/index.ts
+++ b/bigbluebutton-html5/imports/ui/services/livekit/index.ts
@@ -28,6 +28,10 @@ export const isOrphaningDisconnect = (reason?: DisconnectReason): boolean => {
   return reason === undefined || !NON_ORPHANING_DISCONNECT_REASONS.includes(reason);
 };
 
+export const isReconnectingState = (state: ConnectionState): boolean => {
+  return state === ConnectionState.Reconnecting || state === ConnectionState.SignalReconnecting;
+};
+
 export interface LiveKitFatalErrorDetail {
   key: MembershipKey;
   source: string;
@@ -160,6 +164,7 @@ export const lkToggleMuteCameras = (mute: boolean): void => {
 
 export {
   liveKitRoomRegistry,
+  hasConnectedOnce,
   applyRoomOptions,
   resolveRoomOptions,
   DEFAULT_ROOM_OPTIONS,

--- a/bigbluebutton-html5/imports/ui/services/livekit/negotiation-probe.ts
+++ b/bigbluebutton-html5/imports/ui/services/livekit/negotiation-probe.ts
@@ -1,0 +1,88 @@
+import { type Room } from 'livekit-client';
+import logger from '/imports/startup/client/logger';
+
+const SLOW_NEGOTIATION_ANSWER_MS = 3000;
+
+type SignalClient = Room['engine']['client'];
+type OfferHandler = NonNullable<SignalClient['onOffer']>;
+
+const probed = new WeakSet<SignalClient>();
+
+const countMLines = (sd: RTCSessionDescriptionInit): number | undefined => (typeof sd?.sdp === 'string' ? (sd.sdp.match(/^m=/gm) ?? []).length : undefined);
+
+// Track the time it takes for each subscriber offer to be processed locally and
+// handed back to the signal client/socket.
+export const probeSubscriberNegotiation = (room: Room, label: string): void => {
+  const client = (room.engine as Room['engine'] | undefined)?.client;
+
+  if (!client || probed.has(client)) return;
+
+  probed.add(client);
+
+  // Answers in flight, by offer id, so the handler's end can be tied to the
+  // write the SDK does not await.
+  const pendingAnswers = new Map<number, Promise<void>>();
+  const sendAnswer = client.sendAnswer.bind(client);
+  client.sendAnswer = (answer, offerId) => {
+    const sent = sendAnswer(answer, offerId);
+    pendingAnswers.set(offerId, sent);
+    return sent;
+  };
+
+  const wrap = (fn: OfferHandler): OfferHandler => async (sd, offerId, midToTrackId) => {
+    const startedAt = performance.now();
+    const mLines = countMLines(sd);
+    let failure: Error | undefined;
+
+    try {
+      return await fn(sd, offerId, midToTrackId);
+    } catch (error) {
+      failure = error as Error;
+      throw error;
+    } finally {
+      const sent = pendingAnswers.get(offerId);
+      pendingAnswers.delete(offerId);
+      if (sent) await sent.catch(() => undefined);
+      const elapsedMs = Math.round(performance.now() - startedAt);
+      const extraInfo = {
+        label,
+        offerId,
+        mLines,
+        elapsedMs,
+        roomState: room.state,
+        errorName: failure?.name,
+        errorMessage: failure?.message,
+      };
+
+      if (!sent) {
+        logger.warn({
+          logCode: 'livekit_subscriber_offer_unanswered',
+          extraInfo,
+        }, `${label}: subscriber offer ${offerId} was not answered (${elapsedMs} ms)`);
+      } else if (elapsedMs >= SLOW_NEGOTIATION_ANSWER_MS) {
+        logger.warn({
+          logCode: 'livekit_subscriber_offer_answered_slow',
+          extraInfo,
+        }, `${label}: subscriber offer ${offerId} answered in ${elapsedMs} ms`);
+      } else {
+        logger.debug({
+          logCode: 'livekit_subscriber_offer_answered',
+          extraInfo,
+        }, `${label}: subscriber offer ${offerId} answered in ${elapsedMs} ms`);
+      }
+    }
+  };
+
+  let handler: OfferHandler | undefined = client.onOffer ? wrap(client.onOffer) : undefined;
+
+  Object.defineProperty(client, 'onOffer', {
+    configurable: true,
+    enumerable: true,
+    get: () => handler,
+    set: (fn: OfferHandler | undefined) => {
+      handler = fn ? wrap(fn) : undefined;
+    },
+  });
+};
+
+export default probeSubscriberNegotiation;

--- a/bigbluebutton-html5/imports/ui/services/livekit/registry.ts
+++ b/bigbluebutton-html5/imports/ui/services/livekit/registry.ts
@@ -1,8 +1,27 @@
-import { Room, RoomEvent, type RoomOptions } from 'livekit-client';
+import {
+  Room,
+  RoomEvent,
+  type InternalRoomOptions,
+  type RoomOptions,
+} from 'livekit-client';
 
 export type MembershipKey = string; // 'primary' | `breakout-listen:${roomName}` | future kinds
 
 export const PRIMARY_KEY: MembershipKey = 'primary';
+
+export const DEFAULT_ROOM_OPTIONS: Partial<InternalRoomOptions> = {
+  adaptiveStream: true,
+  dynacast: true,
+  singlePeerConnection: false,
+  stopLocalTrackOnUnpublish: false,
+};
+
+// A deployment override may carry only some of the keys; the rest keep the
+// shipped defaults rather than the SDK's.
+export const resolveRoomOptions = (configured?: Partial<InternalRoomOptions>): RoomOptions => ({
+  ...DEFAULT_ROOM_OPTIONS,
+  ...configured,
+});
 
 // A Room reports 'disconnected' both before it has ever connected and after it
 // has been torn down. Only the second state is final, and callers waiting on a
@@ -17,6 +36,20 @@ const trackConnections = (room: Room): Room => {
   return room;
 };
 
+// livekit-client hands the Room's options object to its LocalParticipant by
+// reference at construction and reads the publish-time knobs (dynacast,
+// stopLocalTrackOnUnpublish, publishDefaults) from that same object, so
+// options are merged into it, never swapped for a new object.
+export const applyRoomOptions = (room: Room, options?: RoomOptions): void => {
+  if (options) Object.assign(room.options, options);
+};
+
+// The primary room is created on first touch by whoever asks for it (audio
+// bridge, audio-state hooks), before any membership carries options.
+const configuredRoomOptions = (): RoomOptions => (
+  resolveRoomOptions(window.meetingClientSettings?.public?.media?.livekit?.roomOptions)
+);
+
 class LiveKitRoomRegistry {
   private rooms = new Map<MembershipKey, Room>();
 
@@ -24,10 +57,10 @@ class LiveKitRoomRegistry {
     let room = this.rooms.get(key);
 
     if (!room) {
-      room = trackConnections(new Room(options));
+      room = trackConnections(new Room(options ?? configuredRoomOptions()));
       this.rooms.set(key, room);
-    } else if (options) {
-      room.options = { ...room.options, ...options };
+    } else {
+      applyRoomOptions(room, options);
     }
 
     return room;
@@ -51,14 +84,7 @@ class LiveKitRoomRegistry {
   }
 
   getPrimary(): Room {
-    let room = this.rooms.get(PRIMARY_KEY);
-
-    if (!room) {
-      room = trackConnections(new Room());
-      this.rooms.set(PRIMARY_KEY, room);
-    }
-
-    return room;
+    return this.acquire(PRIMARY_KEY);
   }
 
   has(key: MembershipKey): boolean {

--- a/bigbluebutton-html5/imports/ui/services/livekit/registry.ts
+++ b/bigbluebutton-html5/imports/ui/services/livekit/registry.ts
@@ -71,7 +71,11 @@ class LiveKitRoomRegistry {
 
     if (!room) return;
 
-    this.rooms.delete(key);
+    // The primary room outlives memberships: every bridge, observer and hook
+    // on the page holds it, and a membership deleted and re-created server-side
+    // (eject, rejoin) must reconnect the object they hold rather than orphan it.
+    if (key !== PRIMARY_KEY) this.rooms.delete(key);
+
     room.disconnect().catch(() => {});
   }
 
@@ -85,6 +89,10 @@ class LiveKitRoomRegistry {
 
   getPrimary(): Room {
     return this.acquire(PRIMARY_KEY);
+  }
+
+  isPrimary(room: Room): boolean {
+    return this.rooms.get(PRIMARY_KEY) === room;
   }
 
   has(key: MembershipKey): boolean {

--- a/bigbluebutton-html5/imports/ui/services/livekit/sdk-log-bridge.ts
+++ b/bigbluebutton-html5/imports/ui/services/livekit/sdk-log-bridge.ts
@@ -1,0 +1,105 @@
+import {
+  LogLevel,
+  LoggerNames,
+  setLogExtension,
+  setLogLevel,
+} from 'livekit-client';
+import logger from '/imports/startup/client/logger';
+
+// Constrain SDP content in logs (they can get chunky)
+const SDP_FIELDS = new Set(['sdp', 'mungedSdp', 'originalSdp', 'remoteSdp']);
+const MAX_STRING_LENGTH = 512;
+const MAX_DEPTH = 3;
+
+const summarizeSdp = (sdp: string) => ({
+  length: sdp.length,
+  mLines: (sdp.match(/^m=/gm) ?? []).length,
+});
+
+const SDK_ERROR_DETAIL_FIELDS = new Set(['reason', 'reasonName', 'code', 'status']);
+
+const trimError = (error: Error): Record<string, unknown> => ({
+  name: error.name,
+  message: error.message,
+  ...Object.fromEntries(Object.entries(error).filter(([key]) => SDK_ERROR_DETAIL_FIELDS.has(key))),
+});
+
+const trimValue = (value: unknown, key: string, depth: number): unknown => {
+  if (value instanceof Error) return trimError(value);
+
+  if (typeof value === 'string') {
+    if (SDP_FIELDS.has(key)) return summarizeSdp(value);
+
+    return value.length > MAX_STRING_LENGTH ? `${value.slice(0, MAX_STRING_LENGTH)}...` : value;
+  }
+
+  if (value && typeof value === 'object') {
+    const { sdp } = value as { sdp?: unknown };
+
+    if (typeof sdp === 'string') return { ...summarizeSdp(sdp), type: (value as { type?: unknown }).type };
+
+    if (depth >= MAX_DEPTH) return '[object]';
+
+    if (Array.isArray(value)) return value.slice(0, 20).map((item) => trimValue(item, key, depth + 1));
+
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [k, trimValue(v, k, depth + 1)]),
+    );
+  }
+
+  return value;
+};
+
+let installed = false;
+
+export const installLiveKitSdkLogBridge = (): void => {
+  if (installed) return;
+  installed = true;
+
+  setLogExtension((level, msg, context) => {
+    try {
+      const entry = {
+        logCode: 'livekit_sdk_log',
+        extraInfo: {
+          level: LogLevel[level],
+          context: trimValue(context, '', 0),
+        },
+      };
+
+      const message = `LiveKit SDK: ${msg}`;
+
+      if (level >= LogLevel.error) {
+        logger.error(entry, message);
+      } else if (level === LogLevel.warn) {
+        logger.warn(entry, message);
+      } else if (level === LogLevel.info) {
+        logger.info(entry, message);
+      } else {
+        logger.debug(entry, message);
+      }
+    } catch {
+      // The SDK already wrote the line to the console - "handled"
+    }
+  });
+};
+
+const toLogLevel = (level: LogLevel | string): LogLevel | undefined => {
+  if (typeof level === 'number') return level;
+
+  const wanted = level.toLowerCase();
+
+  const match = Object.entries(LogLevel).find(
+    ([name, value]) => typeof value === 'number' && name.toLowerCase() === wanted,
+  );
+
+  return match ? (match[1] as LogLevel) : undefined;
+};
+
+export const applyLiveKitSdkLogLevel = (level: LogLevel | string): void => {
+  const resolved = toLogLevel(level);
+
+  if (resolved === undefined) return;
+
+  setLogLevel(resolved);
+  setLogLevel(Math.min(resolved, LogLevel.info), LoggerNames.Engine);
+};

--- a/bigbluebutton-html5/package-lock.json
+++ b/bigbluebutton-html5/package-lock.json
@@ -54,7 +54,7 @@
         "html-to-image": "^1.11.13",
         "immutability-helper": "~2.8.1",
         "langmap": "0.0.16",
-        "livekit-client": "2.17.3",
+        "livekit-client": "2.19.0",
         "makeup-screenreader-trap": "0.0.5",
         "postcss-nested": "^7.0.2",
         "prop-types": "^15.8.1",
@@ -3099,9 +3099,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@livekit/protocol": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.44.0.tgz",
-      "integrity": "sha512-/vfhDUGcUKO8Q43r6i+5FrDhl5oZjm/X3U4x2Iciqvgn5C8qbj+57YPcWSJ1kyIZm5Cm6AV2nAPjMm3ETD/iyg==",
+      "version": "1.45.8",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.45.8.tgz",
+      "integrity": "sha512-Q+l57E7w/xxOBFVWzdX5rkAZO7ffyF+rlDzNUYq2SU114+5aTyCq+PK4unaEVDNd4952Af7wteKr3sOgasGuaA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^1.10.0"
@@ -12740,20 +12740,20 @@
       "license": "MIT"
     },
     "node_modules/livekit-client": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.17.3.tgz",
-      "integrity": "sha512-htwsAL/BMylY/zwdcT/z00U789csbi9DldSW7DO+5tz7Q15pwu++E1X+ZdtZDfkmlysfQLLibdcqlyg9FY7veQ==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.19.0.tgz",
+      "integrity": "sha512-aolY1XDAtx0nHKBNm29W9OhzBnSz1CP5kq3phvRhFfi1NbvMXs8tcACjAkZTnIKgihkp+BiJScZZ3tZv0Gz8sA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@livekit/mutex": "1.1.1",
-        "@livekit/protocol": "1.44.0",
+        "@livekit/protocol": "1.45.8",
         "events": "^3.3.0",
         "jose": "^6.1.0",
         "loglevel": "^1.9.2",
         "sdp-transform": "^2.15.0",
         "tslib": "2.8.1",
         "typed-emitter": "^2.1.0",
-        "webrtc-adapter": "^9.0.1"
+        "webrtc-adapter": "9.0.5"
       },
       "peerDependencies": {
         "@types/dom-mediacapture-record": "^1"
@@ -12782,9 +12782,9 @@
       }
     },
     "node_modules/livekit-client/node_modules/webrtc-adapter": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.3.tgz",
-      "integrity": "sha512-5fALBcroIl31OeXAdd1YUntxiZl1eHlZZWzNg3U4Fn+J9/cGL3eT80YlrsWGvj2ojuz1rZr2OXkgCzIxAZ7vRQ==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.5.tgz",
+      "integrity": "sha512-U9vjByy/sK2OMXu5mmfuZFKTMIUQe34c0JXRO+oDrxJTsntdYT2iIFwYMOV7HhMTuktcZLGf2W1N/OcSf9ssWg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "sdp": "^3.2.0"

--- a/bigbluebutton-html5/package.json
+++ b/bigbluebutton-html5/package.json
@@ -98,7 +98,7 @@
     "html-to-image": "^1.11.13",
     "immutability-helper": "~2.8.1",
     "langmap": "0.0.16",
-    "livekit-client": "2.17.3",
+    "livekit-client": "2.19.0",
     "makeup-screenreader-trap": "0.0.5",
     "postcss-nested": "^7.0.2",
     "prop-types": "^15.8.1",

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1028,6 +1028,10 @@ public:
       # reconnectOnFatalFailures: whether to trigger LK room reconnections when
       # fatal errors occur (e.g.: unrecoverable publish timeouts).
       reconnectOnFatalFailures: true
+      # livekit.negotiationProbe: tracks the time, via logs, that it takes
+      # for a subscriber offer to be answered, from receive to socket dispatch.
+      # Debug instrumentation, off by default
+      negotiationProbe: false
       # livekit.forceRelay: forces TURN/relay usage on all UAs when using LK.
       forceRelay: false
       # livekit.forceRelayOnFirefox: forces TURN/relay usage on Firefox when using LK.

--- a/bigbluebutton-html5/private/config/settings.yml
+++ b/bigbluebutton-html5/private/config/settings.yml
@@ -1023,6 +1023,8 @@ public:
         # transitions that would trigger unsubscribe operations.
         muteDebounceMs: 2500
       logLevel: 3
+      # livekit.sdkLogBridge: forward livekit-client's own logs to the client logger.
+      sdkLogBridge: true
       # reconnectOnFatalFailures: whether to trigger LK room reconnections when
       # fatal errors occur (e.g.: unrecoverable publish timeouts).
       reconnectOnFatalFailures: true

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -325,6 +325,7 @@
     "app.media.cameraAsContent.autoplayBlockedDesc": "We need your permission to show you the presenter's camera.",
     "app.media.cameraAsContent.autoplayAllowLabel": "View present camera",
     "app.media.mediaReconnecting": "Connection issue detected. Restoring your audio and video...",
+    "app.media.mediaReconnectFailed": "Could not restore your audio and video. Please refresh your client.",
     "app.screenshare.presenterLoadingLabel": "Your screenshare is loading",
     "app.screenshare.viewerLoadingLabel": "The presenter's screen is loading",
     "app.screenshare.presenterSharingLabel": "You are now sharing your screen",

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1419,6 +1419,8 @@
     "app.video.genericError": "An unknown error has occurred with the device ({error})",
     "app.video.inactiveError": "Your webcam stopped unexpectedly. Please review your browser's permissions",
     "app.video.mediaTimedOutError": "Your webcam stream has been interrupted. Try sharing it again",
+    "app.video.ejectedByModerator": "A moderator has stopped your webcam",
+    "app.video.ejectedByLockSettings": "Your webcam was stopped because webcam sharing is locked",
     "app.video.mediaFlowTimeout1020": "Media could not reach the server (error 1020)",
     "app.video.suggestWebcamLock": "Enforce lock setting to viewers webcams?",
     "app.video.suggestWebcamLockReason": "(this will improve the stability of the session)",


### PR DESCRIPTION
### What does this PR do?

This is an in-depth pass over LiveKit bridges' reconnection and recovery procedures.

The changes here stem from edge cases exploration over two source materials:
production data (logs/metrics) and internal testing.
The goal is to further harden resiliency of media when the client is off the
golden path.

Tests for this work are **not** in this PR. They live on a separate branch and
will follow as their own PR, because several of them are long-running and how we
want to run those in CI has to be discussed separately.

#### In detail

- **build(html5): livekit-client@2.19.0 (up from 2.17.3)** ([`5cb5d65b`](https://github.com/bigbluebutton/bigbluebutton/commit/5cb5d65b96ac5f67d335ad02a70843fdfd34368c))
- **fix(livekit): apply room options where livekit-client reads them** ([`075570e0`](https://github.com/bigbluebutton/bigbluebutton/commit/075570e0d3ef66f207e135c400cd3322c3a9d84b))
  - the SDK reads `stopLocalTrackOnUnpublish`, `dynacast` and `publishDefaults` from the constructor's options object by reference, and every later merge replaced it, so configured values never reached it.
- **fix(livekit): keep the primary Room object across membership changes** ([`5b4e9a62`](https://github.com/bigbluebutton/bigbluebutton/commit/5b4e9a622d929f426456f162be23e7a9802c3760))
  - the registry rebuilt the primary Room on re-acquire, so an eject and rejoin left the audio bridge publishing into a torn-down room until a reload.
- **fix(audio): do not unmute on a voice-conf leave under LiveKit** ([`f2528069`](https://github.com/bigbluebutton/bigbluebutton/commit/f252806996363f5755d307e6db55ac2820355404))
  - that rule assumes a FreeSWITCH breakout transfer; under LiveKit a participant leave is the ordinary reconnect, so a muted user came back publishing unmuted.
- **fix(livekit): skip an audio publish if already republished during a reconnect** ([`a7c0cd4f`](https://github.com/bigbluebutton/bigbluebutton/commit/a7c0cd4fb3c4c4ee44d409e804158b3a21d724cf))
  - the queued publish ran right after the SDK's own republish, and the duplicate timed out and was classified fatal, forcing a second reconnect.
- **fix(livekit): delay a server-triggered mute while the room reconnects** ([`a0947b26`](https://github.com/bigbluebutton/bigbluebutton/commit/a0947b26cf0e9301a3b94069cf2a938455f78b37))
  - the SFU reads a reconnect's transient unpublish as a mute, which silenced a user who never asked for it. The record is read once more when the room settles, so a mute dropped in error is not final.
- **fix(video): fail a LK camera publish cleanly when the preload is gone** ([`95247aa0`](https://github.com/bigbluebutton/bigbluebutton/commit/95247aa0e408b0fa993396c235417c8c5e0e811f))
  - nullish media streams threw uncaught on reconnects and detachments.
- **fix(audio): keep the local mute state set across a GraphQL disconnect** ([`0d6c7387`](https://github.com/bigbluebutton/bigbluebutton/commit/0d6c7387a2bd01d4a747c2a4ab1dab88b8e03bd2))
  - blanking the unmuted set made the button read muted while the microphone was still sending, and the audio state hooks acted on it.
- **fix(livekit): catch unpublish-after-mute failures** ([`651fa489`](https://github.com/bigbluebutton/bigbluebutton/commit/651fa4895a5025e6c67e0c64eb3dcf6ea4a5838b))
  - the deferred unpublish had no rejection handler; it is now cancelled when the room starts reconnecting.
- **fix(livekit): stale audio stream reference when doing a fallback publish** ([`004096bc`](https://github.com/bigbluebutton/bigbluebutton/commit/004096bc6ceb0ac2815a9b0fa9ce76b3880df829))
  - the fallback recorded the old, inactive stream rather than the capture it had just acquired.
- **fix(livekit): cleanup talking state if the room disconnects** ([`031e5930`](https://github.com/bigbluebutton/bigbluebutton/commit/031e5930dd93de3951805042513c80e15b8bfa6d))
  - the server-side cleanup has a deliberately long grace, which left talking indicators stuck.
- **fix(livekit): adjust reconn loop and notify users when it fails for good** ([`1afbbb45`](https://github.com/bigbluebutton/bigbluebutton/commit/1afbbb45adbb6c1b189bca003c4dec7b14ce584c))
  - self-hosted LiveKit has no built-in backoff, and an exhausted loop left a dead client with no indication of what happened.
- **fix(livekit): forcefully reconnect a stalled media session** ([`e16d0941`](https://github.com/bigbluebutton/bigbluebutton/commit/e16d094121f7a7e647e205add9aa3a37b3c4e40f))
  - recovery was conditioned on `RoomEvent.Disconnected`, which the SDK does not always emit, so the room never came back and said nothing. A room held out of connected past 60s is torn down and reconnected, keeping captures.
- **fix(video): surface unexpected camera teardowns to end users** ([`cdc59eb8`](https://github.com/bigbluebutton/bigbluebutton/commit/cdc59eb8f4271c21e2eedcdf2a9742cbf7233743))
  - device failures and reconnects raise a notice; lock settings and ejections get their own server-dispatched notifications, so a deliberate stop is not reported as a fault.
- **fix(livekit): republish a microphone that cannot carry audio** ([`fdfd9a74`](https://github.com/bigbluebutton/bigbluebutton/commit/fdfd9a74fc10cdd4392200f180003f915441ead8))
  - the SDK re-acquires a capture on unmute only for tracks it created itself, so an ended capture came back as an open microphone nobody could hear.
- **fix(livekit): keep a user's cameras in akka across a LiveKit reconnect** ([`bf74ac90`](https://github.com/bigbluebutton/bigbluebutton/commit/bf74ac90ff7cef0746532ac2cab733909cbcbcc5))
  - every forced reconnect closed and re-created the participant, and the handler stopped every webcam of that user. Cleanup moves to the BBB participant ejection. Requires the bbb-webrtc-sfu bump in this PR.
- **refactor(video): set livekit camera subscribe/unsubscribe logs to info** ([`b4493884`](https://github.com/bigbluebutton/bigbluebutton/commit/b44938845b0d68d0d74f79aede48292fdfb6b986))
- **refactor(livekit): pipe livekit-client's logs through the client logger** ([`8824c150`](https://github.com/bigbluebutton/bigbluebutton/commit/8824c150215b4ed304c2c11487f149a1321e018b))
  - SDK logs were console-only, so they could not be gathered from the field. Switchable via `public.media.livekit.sdkLogBridge`.
- **fix(video): resolve a camera against the room before subscribing** ([`5a10c6ef`](https://github.com/bigbluebutton/bigbluebutton/commit/5a10c6effdaa1c7f8d9ca4b79c53b34b0e752d1f))
  - a stale cache entry made the bridge ask for a sid the server no longer had, while the camera republished under a new sid stayed black.
- **feat(livekit): track subscriber offer-answer times on the client** ([`2d422a90`](https://github.com/bigbluebutton/bigbluebutton/commit/2d422a9076d65a6013e8b043b6b76b71370544c8))
  - the server logs only that an answer never arrived within 15s; this says whether the client was slow, never answered, or the offer was slow to reach it. Off by default.
- **fix(livekit): show the placeholder while a remote camera has video** ([`90fc95f3`](https://github.com/bigbluebutton/bigbluebutton/commit/90fc95f373596cd4e8fc094b96ad8f8957d109cb))
  - a dropped or unhealthy remote track left a black square instead of the user's placeholder.
- **build(bbb-webrtc-sfu): v2.25.0-beta.1 (up from v2.25.0-beta.0)** ([`520aaf38`](https://github.com/bigbluebutton/bigbluebutton/commit/520aaf382c3599f592438458e44bd5400ff4829f))
  - carries the deferred per-camera unpublish that `keep a user's cameras in akka across a LiveKit reconnect` depends on.

### Closes Issue(s)

Closes None

### How to test

There's extensive test coverage in a child branch based off this one that was used for the PR. Other than that, some manual hiccups worth remembering:

1. **Transparent signal reconnect**: kill the LiveKit websocket while unmuted.
   Media keeps flowing and the client must stay silent: no reconnect toast, and
   the mute button stays usable. A drop that lasts is still announced.
2. **Camera stopped by a moderator**: enable the Share Webcam lock, and
   separately use *Close cameras* on a sharing user. The user should be told
   what happened; neither should raise the "webcam interrupted" error.
3. **Stalled media**: black-hole the LiveKit signal socket without closing it.
   The client should give up after 60s, reconnect on its own, and say so.

