### PR TITLE
fix: Can't re-enable multi-user whiteboard after reloading the page

### DIFF
--- a/bigbluebutton-html5/imports/ui/core/graphql/comparators/meetingComparator.ts
+++ b/bigbluebutton-html5/imports/ui/core/graphql/comparators/meetingComparator.ts
@@ -57,6 +57,7 @@ export const meetingComparator = <T>(
   if ((aup?.maxUsers ?? 0) !== (bup?.maxUsers ?? 0)) return false;
   if ((aup?.meetingId ?? '') !== (bup?.meetingId ?? '')) return false;
   if ((aup?.meetingLayout ?? '') !== (bup?.meetingLayout ?? '')) return false;
+  if ((aup?.multiUserWhiteboardEnabled ?? false) !== (bup?.multiUserWhiteboardEnabled ?? false)) return false;
   if ((aup?.userCameraCap ?? 0) !== (bup?.userCameraCap ?? 0)) return false;
   if ((aup?.webcamsOnlyForModerator ?? false) !== (bup?.webcamsOnlyForModerator ?? false)) return false;
   if ((aup?.guestLobbyMessage ?? '') !== (bup?.guestLobbyMessage ?? '')) return false;


### PR DESCRIPTION
### What does this PR do?

Adjusts `meetingComparator` to detect changes to `multiUserWhiteboardEnabled` value, so the multiuser whiteboard toggle does not stop working after a page reload.

### Closes Issue(s)
Closes #25770

### How to test
1. Join meeting with two users
2. As the presenter, enable multi-user whiteboard
3. As the presenter, reload the page
4. As the presenter, disable multi-user whiteboard
5. As the presenter, try to enable multi-user whiteboard again