### PR TITLE
feat(recording): rebuild a single playback format with bbb-record --format

### DIFF
--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -47,7 +47,8 @@
 #set -x
 
 unset HEADER WATCH WITHDESC LIST LISTWORKFLOWS LIST WITHDESC REBUILD REBUILDALL \
-      REPUBLISH DELETE DELETEALL CHECK DEBUG CLEAN DISABLE ENABLE TOEXTERNAL TOINTERNAL
+      REPUBLISH DELETE DELETEALL CHECK DEBUG CLEAN DISABLE ENABLE TOEXTERNAL TOINTERNAL \
+      FORMAT
 
 source /etc/bigbluebutton/bigbluebutton-release
 
@@ -94,11 +95,38 @@ declare -r MEETING_PATTERN="^[0-9a-f]\{40\}-[[:digit:]]\{13\}$"
 
 mark_for_rebuild() {
    MEETING_ID=$1
-   echo "Marking for rebuild $MEETING_ID"
+   local FMT=$2
    if [[ ! -d $BASE/raw/$MEETING_ID ]]; then
       echo "Raw files for $MEETING_ID do not exist, can't rebuild"
       exit 1
    fi
+
+  # Single-format rebuild: re-process and re-publish only the requested format,
+  # leaving the sanity step and every other format's output untouched.
+  if [ -n "$FMT" ]; then
+     if ! printf '%s\n' $TYPES | grep -qx "$FMT"; then
+        echo "Unknown format '$FMT'. Valid formats: $(echo $TYPES | tr '\n' ' ')"
+        exit 1
+     fi
+     echo "Marking for rebuild $MEETING_ID (format: $FMT)"
+
+     # Clear out this format's done files only
+     rm -vf "$STATUS"/processed/"$MEETING_ID"-"$FMT".*
+     rm -vf "$STATUS"/published/"$MEETING_ID"-"$FMT".*
+
+     # Remove this format's published + intermediate output
+     rm -rf "${PUBLISHED_DIR:?}"/"$FMT"/"$MEETING_ID"
+     rm -rf "$RAW_PRESENTATION_SRC"/unpublished/"$FMT"/"$MEETING_ID"
+     rm -rf "$RAW_PRESENTATION_SRC"/deleted/"$FMT"/"$MEETING_ID"
+     rm -rf "$BASE"/process/"$FMT"/"$MEETING_ID"
+
+     # Restart processing at the 'process' step for this format only; the steps
+     # workflow chains process:<format> -> publish:<format>.
+     /usr/local/bigbluebutton/core/scripts/rap-enqueue.rb "process:$FMT" "$MEETING_ID"
+     return
+  fi
+
+   echo "Marking for rebuild $MEETING_ID"
 
   # Clear out the relevant done files
   rm -vf "$STATUS"/archived/"$MEETING_ID".norecord
@@ -205,6 +233,8 @@ usage() {
    echo
    echo "Administration:"
    echo "   --rebuild <internal meetingID>     rebuild the output for the given internal meetingID"
+   echo "   --rebuild <internal meetingID> --format <name>"
+   echo "                                      rebuild only one playback format (e.g. presentation, video, ai-summary)"
    echo "   --rebuildall                       rebuild every recording"
    echo "   --delete <internal meetingID>      delete one meeting and recording"
    echo "   --deleteall                        delete all meetings and recordings"
@@ -257,11 +287,19 @@ while [ $# -gt 0 ]; do
    fi
    if [ "$1" = "-rebuild" ] || [ "$1" = "--rebuild" ]; then
       need_root
-      if [ ! -z "${2}" ]; then
+      if [ -n "${2}" ] && [[ "${2}" != -* ]]; then
          MEETING_ID="${2}"
          shift
       fi
       REBUILD=1
+      shift
+      continue
+   fi
+   if [ "$1" = "-format" ] || [ "$1" = "--format" ]; then
+      if [ -n "${2}" ]; then
+         FORMAT="${2}"
+         shift
+      fi
       shift
       continue
    fi
@@ -377,7 +415,7 @@ if [ $REBUILD ]; then
    if [ -z "$MEETING_ID" ]; then
       echo "Pass an internal meeting id as parameter."
    else
-      mark_for_rebuild "$MEETING_ID"
+      mark_for_rebuild "$MEETING_ID" "$FORMAT"
    fi
 fi
 

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -93,6 +93,14 @@ readonly TYPES
 
 declare -r MEETING_PATTERN="^[0-9a-f]\{40\}-[[:digit:]]\{13\}$"
 
+validate_format() {
+   local fmt=$1
+   if ! printf '%s\n' $TYPES | grep -qxF "$fmt"; then
+      echo "Unknown format '$fmt'. Valid formats: ${TYPES//$'\n'/ }"
+      exit 1
+   fi
+}
+
 mark_for_rebuild() {
    MEETING_ID=$1
    local FMT=$2
@@ -104,10 +112,7 @@ mark_for_rebuild() {
   # Single-format rebuild: re-process and re-publish only the requested format,
   # leaving the sanity step and every other format's output untouched.
   if [ -n "$FMT" ]; then
-     if ! printf '%s\n' $TYPES | grep -qx "$FMT"; then
-        echo "Unknown format '$FMT'. Valid formats: $(echo $TYPES | tr '\n' ' ')"
-        exit 1
-     fi
+     validate_format "$FMT"
      echo "Marking for rebuild $MEETING_ID (format: $FMT)"
 
      # Clear out this format's done files only
@@ -147,17 +152,27 @@ mark_for_rebuild() {
 
 mark_for_republish() {
    MEETING_ID=$1
-   echo "Marking for republish $MEETING_ID"
+   local FMT=$2
+   local republish_types=$TYPES
 
-   for type in $TYPES; do
+   # Restrict to a single format when --format was given
+   if [ -n "$FMT" ]; then
+      validate_format "$FMT"
+      republish_types=$FMT
+      echo "Marking for republish $MEETING_ID (format: $FMT)"
+   else
+      echo "Marking for republish $MEETING_ID"
+   fi
+
+   for type in $republish_types; do
       if [[ ! -d $BASE/process/$type/$MEETING_ID ]]; then
          echo "Processed files for $MEETING_ID ($type) do not exist, can't republish"
          echo "Try rebuilding the recording instead."
          continue
       fi
 
-      # Clear out the publish done files
-      rm -vf "$STATUS"/published/"$MEETING_ID"*
+      # Clear out the publish done files for this format only
+      rm -vf "$STATUS"/published/"$MEETING_ID"-"$type".*
 
       # Remove the existing 'published' recording files
       rm -rf "${PUBLISHED_DIR:?}"/"$type"/"$MEETING_ID"
@@ -233,8 +248,8 @@ usage() {
    echo
    echo "Administration:"
    echo "   --rebuild <internal meetingID>     rebuild the output for the given internal meetingID"
-   echo "   --rebuild <internal meetingID> --format <name>"
-   echo "                                      rebuild only one playback format (e.g. presentation, video, ai-summary)"
+   echo "   --format <recording format name>   with --rebuild, --rebuildall or --republish,"
+   echo "                                      act on only one playback format (see --list-workflows)"
    echo "   --rebuildall                       rebuild every recording"
    echo "   --delete <internal meetingID>      delete one meeting and recording"
    echo "   --deleteall                        delete all meetings and recordings"
@@ -296,16 +311,18 @@ while [ $# -gt 0 ]; do
       continue
    fi
    if [ "$1" = "-format" ] || [ "$1" = "--format" ]; then
-      if [ -n "${2}" ]; then
-         FORMAT="${2}"
-         shift
+      if [ -z "${2}" ] || [[ "${2}" == -* ]]; then
+         echo "$1 requires a recording format name, e.g. $1 presentation"
+         echo "Run 'bbb-record --list-workflows' to see the available formats."
+         exit 1
       fi
-      shift
+      FORMAT="${2}"
+      shift 2
       continue
    fi
    if [ "$1" = "-rebuildall" ] || [ "$1" = "--rebuildall" ]; then
       need_root
-      if [ ! -z "${2}" ]; then
+      if [ -n "${2}" ] && [[ "${2}" != -* ]]; then
          MEETING_ID="${2}"
          shift
       fi
@@ -316,7 +333,7 @@ while [ $# -gt 0 ]; do
 
    if [ "$1" = "-republish" ] || [ "$1" = "--republish" ]; then
       need_root
-      if [ ! -z "${2}" ]; then
+      if [ -n "${2}" ] && [[ "${2}" != -* ]]; then
          MEETING_ID="${2}"
          shift
       fi
@@ -422,7 +439,7 @@ fi
 if [ $REBUILDALL ]; then
    echo "Rebuilding all recordings"
    for recording in $(dir "$BASE"/raw); do
-      [[ ! -e $STATUS/archived/$recording.norecord ]] && mark_for_rebuild "$recording"
+      [[ ! -e $STATUS/archived/$recording.norecord ]] && mark_for_rebuild "$recording" "$FORMAT"
    done
 fi
 
@@ -432,12 +449,10 @@ if [ $REPUBLISH ]; then
       # Republish all meetings
       #
       for recording in $(dir "$BASE"/raw); do
-         echo "Marking for republish: $recording"
-         mark_for_republish "$recording"
+         mark_for_republish "$recording" "$FORMAT"
       done
    else
-      echo "Marking for republish: $MEETING_ID"
-      mark_for_republish "$MEETING_ID"
+      mark_for_republish "$MEETING_ID" "$FORMAT"
    fi
 fi
 

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -95,6 +95,12 @@ declare -r MEETING_PATTERN="^[0-9a-f]\{40\}-[[:digit:]]\{13\}$"
 
 validate_format() {
    local fmt=$1
+   # Format names are process script basenames and are substituted into paths,
+   # yq expressions and rm globs below, so reject anything else up front.
+   if ! [[ $fmt =~ ^[a-z0-9_]+$ ]]; then
+      echo "Format '$fmt' contains invalid characters"
+      exit 1
+   fi
    if ! printf '%s\n' $TYPES | grep -qxF "$fmt"; then
       echo "Unknown format '$fmt'. Valid formats: ${TYPES//$'\n'/ }"
       exit 1
@@ -107,25 +113,23 @@ validate_format() {
 disabled_formats() {
    local id=$1
    local events=$RECORDING_DIR/raw/$id/events.xml
-   # No events.xml means there is no opt-out to honour. Anything else we cannot
-   # read is reported as a failure, so callers refuse instead of assuming.
-   [ -e "$events" ] || return 0
-   if [ ! -f "$events" ] || [ ! -r "$events" ]; then
-      return 1
-   fi
-   # Almost no meeting carries the parameter, and parsing the XML costs a ruby
-   # start-up per meeting, so only pay for it when the attribute is present.
-   grep -q 'bbb-disable-recording-formats' "$events"
+   local disabled_formats
+
+   # Same parsing as BigBlueButton::Events.disabled_recording_formats, without
+   # a ruby start-up per meeting. xmlstarlet exits 1 when the XPath selects
+   # nothing, which here just means the meeting never opted out; any other
+   # failure (missing, unreadable or malformed events.xml) is reported.
+   disabled_formats=$(xmlstarlet sel -t -v /recording/metadata/@bbb-disable-recording-formats "$events" 2>/dev/null)
    case $? in
-      0) ;;          # present: read it authoritatively below
-      1) return 0 ;; # definitely absent
-      *) return 1 ;; # could not be read
+      0) ;;
+      1) return 0 ;;
+      *) return 1 ;;
    esac
-   ruby -e '
-      $LOAD_PATH.unshift("/usr/local/bigbluebutton/core/lib")
-      require "recordandplayback"
-      puts BigBlueButton.disabled_recording_formats(ARGV[0], ARGV[1], strict: true).join(" ")
-   ' "$RECORDING_DIR" "$id"
+
+   disabled_formats=${disabled_formats//[\[\]]} # delete [ and ]
+   disabled_formats=${disabled_formats//,/ }    # replace commas with spaces
+   disabled_formats=${disabled_formats,,}       # convert to lowercase
+   echo "$disabled_formats"
 }
 
 # May we touch this format for this meeting? Checked before anything is
@@ -147,15 +151,23 @@ format_allowed() {
 }
 
 # What the steps chain runs after the given step, empty if the chain has no
-# entry for it. read_props shallow-merges the override, so an override that
-# defines 'steps' replaces the whole map rather than adding to it.
+# next step for it. Like read_props, the override is merged shallowly onto
+# bigbluebutton.yml: an override that defines 'steps' replaces the whole map
+# rather than adding to it, so the last file with a 'steps' map wins.
 step_after() {
-   local step=$1 file=$BBB_YML
+   local step=$1
+   # check for unexpected characters - no escaping is performed in yq expression substitution
+   [[ $step =~ ^[a-z0-9_:]+$ ]] || return 1
+
+   local -a files=( "$BBB_YML" )
    local override=/etc/bigbluebutton/recording/recording.yml
-   if [ -f "$override" ] && [ -n "$(yq e '.steps // ""' "$override" 2>/dev/null)" ]; then
-      file=$override
+   if [[ -e "$override" ]]; then
+      files+=("$override")
    fi
-   yq e ".steps.\"$step\" // \"\"" "$file" 2>/dev/null
+
+   # Take the 'steps' map from the last file that defines one, rather than
+   # merging the documents, so an override's map replaces the default one.
+   yq ea '[.steps | select(. != null)] | .[-1] | ."'"${step}"'" // ""' "${files[@]}" 2>/dev/null
 }
 
 # Remove a format's status files for the meeting, from the given $STATUS
@@ -167,8 +179,13 @@ step_after() {
 # side to grow a break timestamp first.
 remove_format_status() {
    local id=$1 fmt=$2 sub
+   if [ -z "$id" ] || [ -z "$fmt" ]; then
+      echo "remove_format_status: meeting id and format are required" >&2
+      return 1
+   fi
    for sub in "${@:3}"; do
-      rm -vf "$STATUS"/"$sub"/"$id"-"$fmt".*
+      [ -n "$sub" ] || continue
+      rm -vf "${STATUS:?}"/"$sub"/"$id"-"$fmt".*
    done
 }
 
@@ -176,6 +193,10 @@ remove_format_status() {
 # for the reason given on remove_format_status above.
 remove_published_output() {
    local id=$1 fmt=$2 dir
+   if [ -z "$id" ] || [ -z "$fmt" ]; then
+      echo "remove_published_output: meeting id and format are required" >&2
+      return 1
+   fi
    for dir in "${PUBLISHED_DIR:?}"/"$fmt" \
               "$RAW_PRESENTATION_SRC"/unpublished/"$fmt" \
               "$RAW_PRESENTATION_SRC"/deleted/"$fmt"; do
@@ -184,8 +205,12 @@ remove_published_output() {
 }
 
 mark_for_rebuild() {
-   MEETING_ID=$1
+   local MEETING_ID=$1
    local FMT=$2
+   if [ -z "$MEETING_ID" ]; then
+      echo "mark_for_rebuild: no meeting id given" >&2
+      return 1
+   fi
    if [[ ! -d $BASE/raw/$MEETING_ID ]]; then
       echo "Raw files for $MEETING_ID do not exist, can't rebuild"
       return 1
@@ -231,10 +256,14 @@ mark_for_rebuild() {
 }
 
 mark_for_republish() {
-   MEETING_ID=$1
+   local MEETING_ID=$1
    local FMT=$2
    local republish_types=$TYPES
    local republished=0
+   if [ -z "$MEETING_ID" ]; then
+      echo "mark_for_republish: no meeting id given" >&2
+      return 1
+   fi
 
    # Restrict to a single format when --format was given
    if [ -n "$FMT" ]; then
@@ -531,8 +560,8 @@ if [ -n "$FORMAT" ]; then
    # Processing a format the steps chain does not continue would remove the
    # current output and never publish a replacement.
    if [ -n "$REBUILD$REBUILDALL" ] && [ -z "$(step_after "process:$FORMAT")" ]; then
-      echo "Format '$FORMAT' has no 'process:$FORMAT' entry in the recording steps chain,"
-      echo "so processing it would never publish a result."
+      echo "The recording steps chain has no next step after 'process:$FORMAT',"
+      echo "so processing format '$FORMAT' would never publish a result."
       echo "Run 'bbb-record --list-workflows' to see the enabled steps. Nothing was removed."
       exit 1
    fi

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -101,18 +101,39 @@ validate_format() {
    fi
 }
 
-# Is a recording format disabled for this meeting through the
-# meta_bbb-disable-recording-formats create parameter? Checked before anything
-# is removed: rap-enqueue would refuse the job, leaving the output deleted with
-# nothing scheduled to rebuild it.
-format_disabled() {
-   local id=$1 fmt=$2
+# The recording formats this meeting opted out of through the
+# meta_bbb-disable-recording-formats create parameter, space separated.
+# Non-zero exit means the metadata could not be read at all.
+disabled_formats() {
+   local id=$1
+   local events=$RECORDING_DIR/raw/$id/events.xml
+   [ -f "$events" ] || return 0
+   # Almost no meeting carries the parameter, and parsing the XML costs a ruby
+   # start-up per meeting, so only pay for it when the attribute is present.
+   grep -q 'bbb-disable-recording-formats' "$events" || return 0
    ruby -e '
       $LOAD_PATH.unshift("/usr/local/bigbluebutton/core/lib")
       require "recordandplayback"
-      exit(BigBlueButton.disabled_recording_formats(ARGV[0], ARGV[1])
-                        .include?(ARGV[2].downcase) ? 0 : 1)
-   ' "$RECORDING_DIR" "$id" "$fmt" 2>/dev/null
+      puts BigBlueButton.disabled_recording_formats(ARGV[0], ARGV[1]).join(" ")
+   ' "$RECORDING_DIR" "$id"
+}
+
+# May we touch this format for this meeting? Checked before anything is
+# removed: rap-enqueue refuses an opted-out format, which would otherwise leave
+# the output deleted with nothing scheduled to rebuild it. A metadata read
+# failure refuses too, rather than being taken for "not disabled".
+format_allowed() {
+   local id=$1 fmt=$2 list f
+   if ! list=$(disabled_formats "$id"); then
+      echo "Could not read the disabled recording formats for $id, refusing to touch it."
+      return 1
+   fi
+   for f in $list; do
+      if [ "$f" = "${fmt,,}" ]; then
+         echo "Format '$fmt' is disabled for $id by meta_bbb-disable-recording-formats."
+         return 1
+      fi
+   done
 }
 
 # What the steps chain runs after the given step, empty if the chain has no
@@ -152,16 +173,15 @@ mark_for_rebuild() {
    local FMT=$2
    if [[ ! -d $BASE/raw/$MEETING_ID ]]; then
       echo "Raw files for $MEETING_ID do not exist, can't rebuild"
-      exit 1
+      return 1
    fi
 
   # Single-format rebuild: re-process and re-publish only the requested format,
   # leaving the sanity step and every other format's output untouched.
   if [ -n "$FMT" ]; then
-     if format_disabled "$MEETING_ID" "$FMT"; then
-        echo "Format '$FMT' is disabled for $MEETING_ID by meta_bbb-disable-recording-formats."
-        echo "Nothing was removed."
-        exit 1
+     if ! format_allowed "$MEETING_ID" "$FMT"; then
+        echo "Nothing was removed for $MEETING_ID."
+        return 1
      fi
      echo "Marking for rebuild $MEETING_ID (format: $FMT)"
 
@@ -203,10 +223,9 @@ mark_for_republish() {
 
    # Restrict to a single format when --format was given
    if [ -n "$FMT" ]; then
-      if format_disabled "$MEETING_ID" "$FMT"; then
-         echo "Format '$FMT' is disabled for $MEETING_ID by meta_bbb-disable-recording-formats."
-         echo "Nothing was removed."
-         exit 1
+      if ! format_allowed "$MEETING_ID" "$FMT"; then
+         echo "Nothing was removed for $MEETING_ID."
+         return 1
       fi
       republish_types=$FMT
       echo "Marking for republish $MEETING_ID (format: $FMT)"
@@ -221,8 +240,7 @@ mark_for_republish() {
          continue
       fi
 
-      if format_disabled "$MEETING_ID" "$type"; then
-         echo "Skipping $type for $MEETING_ID: disabled by meta_bbb-disable-recording-formats"
+      if ! format_allowed "$MEETING_ID" "$type"; then
          continue
       fi
 
@@ -509,7 +527,7 @@ if [ $REBUILD ]; then
    if [ -z "$MEETING_ID" ]; then
       echo "Pass an internal meeting id as parameter."
    else
-      mark_for_rebuild "$MEETING_ID" "$FORMAT"
+      mark_for_rebuild "$MEETING_ID" "$FORMAT" || exit 1
    fi
 fi
 

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -101,6 +101,20 @@ validate_format() {
    fi
 }
 
+# Is a recording format disabled for this meeting through the
+# meta_bbb-disable-recording-formats create parameter? Checked before anything
+# is removed: rap-enqueue would refuse the job, leaving the output deleted with
+# nothing scheduled to rebuild it.
+format_disabled() {
+   local id=$1 fmt=$2
+   ruby -e '
+      $LOAD_PATH.unshift("/usr/local/bigbluebutton/core/lib")
+      require "recordandplayback"
+      exit(BigBlueButton.disabled_recording_formats(ARGV[0], ARGV[1])
+                        .include?(ARGV[2].downcase) ? 0 : 1)
+   ' "$RECORDING_DIR" "$id" "$fmt" 2>/dev/null
+}
+
 mark_for_rebuild() {
    MEETING_ID=$1
    local FMT=$2
@@ -113,6 +127,11 @@ mark_for_rebuild() {
   # leaving the sanity step and every other format's output untouched.
   if [ -n "$FMT" ]; then
      validate_format "$FMT"
+     if format_disabled "$MEETING_ID" "$FMT"; then
+        echo "Format '$FMT' is disabled for $MEETING_ID by meta_bbb-disable-recording-formats."
+        echo "Nothing was removed."
+        exit 1
+     fi
      echo "Marking for rebuild $MEETING_ID (format: $FMT)"
 
      # Clear out this format's done files only
@@ -158,6 +177,11 @@ mark_for_republish() {
    # Restrict to a single format when --format was given
    if [ -n "$FMT" ]; then
       validate_format "$FMT"
+      if format_disabled "$MEETING_ID" "$FMT"; then
+         echo "Format '$FMT' is disabled for $MEETING_ID by meta_bbb-disable-recording-formats."
+         echo "Nothing was removed."
+         exit 1
+      fi
       republish_types=$FMT
       echo "Marking for republish $MEETING_ID (format: $FMT)"
    else
@@ -168,6 +192,11 @@ mark_for_republish() {
       if [[ ! -d $BASE/process/$type/$MEETING_ID ]]; then
          echo "Processed files for $MEETING_ID ($type) do not exist, can't republish"
          echo "Try rebuilding the recording instead."
+         continue
+      fi
+
+      if format_disabled "$MEETING_ID" "$type"; then
+         echo "Skipping $type for $MEETING_ID: disabled by meta_bbb-disable-recording-formats"
          continue
       fi
 

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -115,6 +115,38 @@ format_disabled() {
    ' "$RECORDING_DIR" "$id" "$fmt" 2>/dev/null
 }
 
+# What the steps chain runs after the given step, empty if the chain has no
+# entry for it. read_props shallow-merges the override, so an override that
+# defines 'steps' replaces the whole map rather than adding to it.
+step_after() {
+   local step=$1 file=$BBB_YML
+   local override=/etc/bigbluebutton/recording/recording.yml
+   if [ -f "$override" ] && [ -n "$(yq e '.steps // ""' "$override" 2>/dev/null)" ]; then
+      file=$override
+   fi
+   yq e ".steps.\"$step\" // \"\"" "$file" 2>/dev/null
+}
+
+# Remove a format's status files from the given $STATUS subdirectories, for the
+# meeting and for each of its segments (<meeting id>-<break timestamp>-<format>).
+remove_format_status() {
+   local id=$1 fmt=$2 sub
+   for sub in "${@:3}"; do
+      rm -vf "$STATUS"/"$sub"/"$id"-"$fmt".* "$STATUS"/"$sub"/"$id"-[0-9]*-"$fmt".*
+   done
+}
+
+# Remove a format's published output for the meeting and for each of its
+# segments (<meeting id>-<break timestamp>).
+remove_published_output() {
+   local id=$1 fmt=$2 dir
+   for dir in "${PUBLISHED_DIR:?}"/"$fmt" \
+              "$RAW_PRESENTATION_SRC"/unpublished/"$fmt" \
+              "$RAW_PRESENTATION_SRC"/deleted/"$fmt"; do
+      rm -rf "$dir"/"$id" "$dir"/"$id"-[0-9]*
+   done
+}
+
 mark_for_rebuild() {
    MEETING_ID=$1
    local FMT=$2
@@ -126,7 +158,6 @@ mark_for_rebuild() {
   # Single-format rebuild: re-process and re-publish only the requested format,
   # leaving the sanity step and every other format's output untouched.
   if [ -n "$FMT" ]; then
-     validate_format "$FMT"
      if format_disabled "$MEETING_ID" "$FMT"; then
         echo "Format '$FMT' is disabled for $MEETING_ID by meta_bbb-disable-recording-formats."
         echo "Nothing was removed."
@@ -135,14 +166,11 @@ mark_for_rebuild() {
      echo "Marking for rebuild $MEETING_ID (format: $FMT)"
 
      # Clear out this format's done files only
-     rm -vf "$STATUS"/processed/"$MEETING_ID"-"$FMT".*
-     rm -vf "$STATUS"/published/"$MEETING_ID"-"$FMT".*
+     remove_format_status "$MEETING_ID" "$FMT" processed published
 
      # Remove this format's published + intermediate output
-     rm -rf "${PUBLISHED_DIR:?}"/"$FMT"/"$MEETING_ID"
-     rm -rf "$RAW_PRESENTATION_SRC"/unpublished/"$FMT"/"$MEETING_ID"
-     rm -rf "$RAW_PRESENTATION_SRC"/deleted/"$FMT"/"$MEETING_ID"
-     rm -rf "$BASE"/process/"$FMT"/"$MEETING_ID"
+     remove_published_output "$MEETING_ID" "$FMT"
+     rm -rf "$BASE"/process/"$FMT"/"$MEETING_ID" "$BASE"/process/"$FMT"/"$MEETING_ID"-[0-9]*
 
      # Restart processing at the 'process' step for this format only; the steps
      # workflow chains process:<format> -> publish:<format>.
@@ -160,9 +188,7 @@ mark_for_rebuild() {
 
   # Remove the existing 'published' recording files
   for type in $TYPES; do
-     rm -rf "${PUBLISHED_DIR:?}"/"$type"/"$MEETING_ID"
-     rm -rf "$RAW_PRESENTATION_SRC"/unpublished/"$type"/"$MEETING_ID"
-     rm -rf "$RAW_PRESENTATION_SRC"/deleted/"$type"/"$MEETING_ID"
+     remove_published_output "$MEETING_ID" "$type"
   done
 
   # Restart processing at the 'sanity' step
@@ -173,10 +199,10 @@ mark_for_republish() {
    MEETING_ID=$1
    local FMT=$2
    local republish_types=$TYPES
+   local republished=0
 
    # Restrict to a single format when --format was given
    if [ -n "$FMT" ]; then
-      validate_format "$FMT"
       if format_disabled "$MEETING_ID" "$FMT"; then
          echo "Format '$FMT' is disabled for $MEETING_ID by meta_bbb-disable-recording-formats."
          echo "Nothing was removed."
@@ -201,16 +227,21 @@ mark_for_republish() {
       fi
 
       # Clear out the publish done files for this format only
-      rm -vf "$STATUS"/published/"$MEETING_ID"-"$type".*
+      remove_format_status "$MEETING_ID" "$type" published
 
       # Remove the existing 'published' recording files
-      rm -rf "${PUBLISHED_DIR:?}"/"$type"/"$MEETING_ID"
-      rm -rf "$RAW_PRESENTATION_SRC"/unpublished/"$type"/"$MEETING_ID"
-      rm -rf "$RAW_PRESENTATION_SRC"/deleted/"$type"/"$MEETING_ID"
+      remove_published_output "$MEETING_ID" "$type"
 
       # Restart processing at the 'publish' step
       /usr/local/bigbluebutton/core/scripts/rap-enqueue.rb "publish:$type" "$MEETING_ID"
+      republished=1
    done
+
+   # An explicit single-format request that republished nothing is a failure,
+   # not a silent no-op. Sweeping every meeting stays best-effort.
+   if [ -n "$FMT" ] && [ "$republished" = 0 ]; then
+      return 1
+   fi
 }
 
 need_root() {
@@ -457,6 +488,23 @@ while [ $# -gt 0 ]; do
    exit 1
 done
 
+# Validate --format once, before any action touches the filesystem.
+if [ -n "$FORMAT" ]; then
+   if [ -z "$REBUILD$REBUILDALL$REPUBLISH" ]; then
+      echo "--format only applies to --rebuild, --rebuildall or --republish."
+      exit 1
+   fi
+   validate_format "$FORMAT"
+   # Processing a format the steps chain does not continue would remove the
+   # current output and never publish a replacement.
+   if [ -n "$REBUILD$REBUILDALL" ] && [ -z "$(step_after "process:$FORMAT")" ]; then
+      echo "Format '$FORMAT' has no 'process:$FORMAT' entry in the recording steps chain,"
+      echo "so processing it would never publish a result."
+      echo "Run 'bbb-record --list-workflows' to see the enabled steps. Nothing was removed."
+      exit 1
+   fi
+fi
+
 if [ $REBUILD ]; then
    if [ -z "$MEETING_ID" ]; then
       echo "Pass an internal meeting id as parameter."
@@ -481,7 +529,7 @@ if [ $REPUBLISH ]; then
          mark_for_republish "$recording" "$FORMAT"
       done
    else
-      mark_for_republish "$MEETING_ID" "$FORMAT"
+      mark_for_republish "$MEETING_ID" "$FORMAT" || exit 1
    fi
 fi
 

--- a/bigbluebutton-config/bin/bbb-record
+++ b/bigbluebutton-config/bin/bbb-record
@@ -107,14 +107,24 @@ validate_format() {
 disabled_formats() {
    local id=$1
    local events=$RECORDING_DIR/raw/$id/events.xml
-   [ -f "$events" ] || return 0
+   # No events.xml means there is no opt-out to honour. Anything else we cannot
+   # read is reported as a failure, so callers refuse instead of assuming.
+   [ -e "$events" ] || return 0
+   if [ ! -f "$events" ] || [ ! -r "$events" ]; then
+      return 1
+   fi
    # Almost no meeting carries the parameter, and parsing the XML costs a ruby
    # start-up per meeting, so only pay for it when the attribute is present.
-   grep -q 'bbb-disable-recording-formats' "$events" || return 0
+   grep -q 'bbb-disable-recording-formats' "$events"
+   case $? in
+      0) ;;          # present: read it authoritatively below
+      1) return 0 ;; # definitely absent
+      *) return 1 ;; # could not be read
+   esac
    ruby -e '
       $LOAD_PATH.unshift("/usr/local/bigbluebutton/core/lib")
       require "recordandplayback"
-      puts BigBlueButton.disabled_recording_formats(ARGV[0], ARGV[1]).join(" ")
+      puts BigBlueButton.disabled_recording_formats(ARGV[0], ARGV[1], strict: true).join(" ")
    ' "$RECORDING_DIR" "$id"
 }
 
@@ -148,23 +158,28 @@ step_after() {
    yq e ".steps.\"$step\" // \"\"" "$file" 2>/dev/null
 }
 
-# Remove a format's status files from the given $STATUS subdirectories, for the
-# meeting and for each of its segments (<meeting id>-<break timestamp>-<format>).
+# Remove a format's status files for the meeting, from the given $STATUS
+# subdirectories.
+#
+# Segment artifacts (<meeting id>-<break timestamp>-<format>) are deliberately
+# left alone: rap-enqueue.rb can only enqueue a bare meeting id, so a segment
+# removed here would never be rebuilt. Rebuilding segments needs the enqueue
+# side to grow a break timestamp first.
 remove_format_status() {
    local id=$1 fmt=$2 sub
    for sub in "${@:3}"; do
-      rm -vf "$STATUS"/"$sub"/"$id"-"$fmt".* "$STATUS"/"$sub"/"$id"-[0-9]*-"$fmt".*
+      rm -vf "$STATUS"/"$sub"/"$id"-"$fmt".*
    done
 }
 
-# Remove a format's published output for the meeting and for each of its
-# segments (<meeting id>-<break timestamp>).
+# Remove a format's published output for the meeting. Segments are left alone,
+# for the reason given on remove_format_status above.
 remove_published_output() {
    local id=$1 fmt=$2 dir
    for dir in "${PUBLISHED_DIR:?}"/"$fmt" \
               "$RAW_PRESENTATION_SRC"/unpublished/"$fmt" \
               "$RAW_PRESENTATION_SRC"/deleted/"$fmt"; do
-      rm -rf "$dir"/"$id" "$dir"/"$id"-[0-9]*
+      rm -rf "$dir"/"$id"
    done
 }
 
@@ -190,7 +205,7 @@ mark_for_rebuild() {
 
      # Remove this format's published + intermediate output
      remove_published_output "$MEETING_ID" "$FMT"
-     rm -rf "$BASE"/process/"$FMT"/"$MEETING_ID" "$BASE"/process/"$FMT"/"$MEETING_ID"-[0-9]*
+     rm -rf "$BASE"/process/"$FMT"/"$MEETING_ID"
 
      # Restart processing at the 'process' step for this format only; the steps
      # workflow chains process:<format> -> publish:<format>.

--- a/build/packages-template/bbb-config/opts-jammy.sh
+++ b/build/packages-template/bbb-config/opts-jammy.sh
@@ -3,4 +3,4 @@
 . ./opts-global.sh
 
 AKKA_APPS="bbb-fsesl-akka,bbb-apps-akka"
-OPTS="$OPTS -t deb -d netcat-openbsd,stun-client,bbb-playback-presentation,bbb-html5,bbb-playback,bbb-freeswitch-core,$AKKA_APPS,bbb-web,yq"
+OPTS="$OPTS -t deb -d netcat-openbsd,stun-client,bbb-playback-presentation,bbb-html5,bbb-playback,bbb-freeswitch-core,$AKKA_APPS,bbb-web,yq,xmlstarlet"

--- a/docs/docs/administration/customize.md
+++ b/docs/docs/administration/customize.md
@@ -380,6 +380,8 @@ This pattern can be repeated for additional recording formats. Note that it's ve
 
 After you edit the configuration file, you must restart the recording processing queue: `systemctl restart bbb-rap-resque-worker.service` in order to pick up the changes.
 
+You can confirm the result with `bbb-record --list-workflows`, which lists the enabled processing steps separately from the installed processing scripts. A format that appears only under the installed scripts is not part of the workflow yet, and `bbb-record --rebuild <recording_id> --format formatname` will refuse to rebuild it, because processing it would remove the existing output without publishing a replacement.
+
 To disable one or more enabled recording formats for a single meeting, pass `meta_bbb-disable-recording-formats` on the `create` API call with a comma-separated list of format names. For example, `meta_bbb-disable-recording-formats=video,presentation` (or `meta_bbb-disable-recording-formats=[video,presentation]`) skips the `video` and `presentation` recording formats for that meeting. The format names are case-insensitive and match the format part of the recording steps. Disabled formats are not processed or published, so they do not trigger recording-ready callbacks.
 
 The following script will enable the video recording format of a BigBlueButton 2.6+ server.

--- a/docs/docs/development/recording.md
+++ b/docs/docs/development/recording.md
@@ -153,6 +153,8 @@ Monitoring:
 
 Administration:
    --rebuild <internal meetingID>      rebuild the output for the given internal meetingID
+   --format <recording format name>    with --rebuild, --rebuildall or --republish,
+                                       act on only one playback format (see --list-workflows)
    --rebuildall                        rebuild every recording
    --delete <internal meetingID>       delete one meeting and recording
    --deleteall                         delete all meetings and recordings
@@ -269,6 +271,30 @@ If you run `bbb-record --rebuild` on a recording where the process and publish s
 $ sudo bbb-record --rebuild 29173583cf1ca21508b2efd7db566090bbefb36a-1647630316965
 ```
 
+#### Rebuild a single recording format
+
+Adding `--format` to `--rebuild` re-processes and re-publishes only the named
+playback format, leaving the sanity step and every other format's output alone.
+Rebuilding every format takes a long time, so this is useful when a single
+format failed, or when testing changes to one format's scripts.
+
+```bash
+$ sudo bbb-record --rebuild 29173583cf1ca21508b2efd7db566090bbefb36a-1647630316965 --format video
+```
+
+The format has to be *enabled* in the recording steps, not merely installed.
+`bbb-record --list-workflows` prints both lists, and installing a
+`bbb-playback-formatname` package does not enable the format on its own (see
+[#12241](https://github.com/bigbluebutton/bigbluebutton/issues/12241) and
+[Install additional recording processing formats](/administration/customize#install-additional-recording-processing-formats)).
+A format with no `process:formatname` step would have its existing output
+removed and never republished, so `bbb-record` refuses it and changes nothing.
+
+A format the meeting opted out of with `meta_bbb-disable-recording-formats` is
+also refused, so that a rebuild cannot undo the opt-out.
+
+`--format` also works with `--rebuildall` and `--republish`.
+
 #### Rebuild every recording
 
 This option goes through the Process and Publish phases again for every recording in your server.
@@ -363,11 +389,15 @@ English 102" meetingName="English 102
 
 #### Republish recordings
 
-Republish recordings.
+Republish recordings. This runs the Publish phase again without re-processing,
+so it requires the processed files to still be present.
 
 ```bash
 $ sudo bbb-record --republish 29173583cf1ca21508b2efd7db566090bbefb36a-1647630316965
 ```
+
+Add `--format` to republish only one playback format, as described in
+[Rebuild a single recording format](#rebuild-a-single-recording-format).
 
 ### For Developers
 

--- a/record-and-playback/core/lib/recordandplayback.rb
+++ b/record-and-playback/core/lib/recordandplayback.rb
@@ -252,6 +252,26 @@ module BigBlueButton
     @props
   end
 
+  # Recording formats a meeting opted out of via the
+  # meta_bbb-disable-recording-formats create parameter.
+  #
+  # @return [Array<String>] lowercased format names
+  def self.disabled_recording_formats(recording_dir, meeting_id)
+    events_xml = File.join(recording_dir, 'raw', meeting_id, 'events.xml')
+    return [] unless File.exist?(events_xml)
+
+    metadata = BigBlueButton::Events.get_meeting_metadata(events_xml)
+    value = metadata['bbb-disable-recording-formats']
+    value = value.nil? ? '' : value.value.to_s
+    value.delete('[]')
+         .split(',')
+         .map { |format| format.strip.downcase }
+         .reject(&:empty?)
+  rescue StandardError => e
+    BigBlueButton.logger.warn("Failed to read bbb-disable-recording-formats metadata: #{e.message}")
+    []
+  end
+
   def self.create_redis_publisher
     props = BigBlueButton.read_props
     redis_host = props['redis_host']

--- a/record-and-playback/core/lib/recordandplayback.rb
+++ b/record-and-playback/core/lib/recordandplayback.rb
@@ -255,8 +255,13 @@ module BigBlueButton
   # Recording formats a meeting opted out of via the
   # meta_bbb-disable-recording-formats create parameter.
   #
+  # The metadata is unreadable rarely enough that the processing pipeline treats
+  # a failure as "nothing disabled" and carries on. Callers that remove output
+  # before acting on the answer must not do that, so they pass strict: true and
+  # get the error instead.
+  #
   # @return [Array<String>] lowercased format names
-  def self.disabled_recording_formats(recording_dir, meeting_id)
+  def self.disabled_recording_formats(recording_dir, meeting_id, strict: false)
     events_xml = File.join(recording_dir, 'raw', meeting_id, 'events.xml')
     return [] unless File.exist?(events_xml)
 
@@ -268,6 +273,8 @@ module BigBlueButton
          .map { |format| format.strip.downcase }
          .reject(&:empty?)
   rescue StandardError => e
+    raise if strict
+
     BigBlueButton.logger.warn("Failed to read bbb-disable-recording-formats metadata: #{e.message}")
     []
   end

--- a/record-and-playback/core/lib/recordandplayback.rb
+++ b/record-and-playback/core/lib/recordandplayback.rb
@@ -252,33 +252,6 @@ module BigBlueButton
     @props
   end
 
-  # Recording formats a meeting opted out of via the
-  # meta_bbb-disable-recording-formats create parameter.
-  #
-  # The metadata is unreadable rarely enough that the processing pipeline treats
-  # a failure as "nothing disabled" and carries on. Callers that remove output
-  # before acting on the answer must not do that, so they pass strict: true and
-  # get the error instead.
-  #
-  # @return [Array<String>] lowercased format names
-  def self.disabled_recording_formats(recording_dir, meeting_id, strict: false)
-    events_xml = File.join(recording_dir, 'raw', meeting_id, 'events.xml')
-    return [] unless File.exist?(events_xml)
-
-    metadata = BigBlueButton::Events.get_meeting_metadata(events_xml)
-    value = metadata['bbb-disable-recording-formats']
-    value = value.nil? ? '' : value.value.to_s
-    value.delete('[]')
-         .split(',')
-         .map { |format| format.strip.downcase }
-         .reject(&:empty?)
-  rescue StandardError => e
-    raise if strict
-
-    BigBlueButton.logger.warn("Failed to read bbb-disable-recording-formats metadata: #{e.message}")
-    []
-  end
-
   def self.create_redis_publisher
     props = BigBlueButton.read_props
     redis_host = props['redis_host']

--- a/record-and-playback/core/lib/recordandplayback/generators/events.rb
+++ b/record-and-playback/core/lib/recordandplayback/generators/events.rb
@@ -79,6 +79,21 @@ module BigBlueButton
     end
 
 
+    # Recording formats the meeting opted out of through the
+    # meta_bbb-disable-recording-formats create parameter.
+    #
+    # @param events [Nokogiri::XML::Document] the parsed events.xml
+    # @return [Array<String>] lowercased format names, empty when the meeting did not opt out
+    def self.disabled_recording_formats(events)
+      value = events.at_xpath('/recording/metadata/@bbb-disable-recording-formats')&.value
+      return [] if value.nil?
+
+      value.delete('[]')
+           .split(',')
+           .map { |format| format.strip.downcase }
+           .reject(&:empty?)
+    end
+
     # Get the external meeting id
     def self.get_external_meeting_id(events_xml)
       BigBlueButton.logger.info("Task: Getting external meeting id")

--- a/record-and-playback/core/lib/recordandplayback/workers/base_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/base_worker.rb
@@ -119,8 +119,17 @@ module BigBlueButton
       end
 
       def disabled_recording_formats
-        @disabled_recording_formats ||=
-          BigBlueButton.disabled_recording_formats(@recording_dir, @meeting_id)
+        return @disabled_recording_formats unless @disabled_recording_formats.nil?
+
+        @disabled_recording_formats = []
+        events_xml = File.join(@recording_dir, 'raw', @meeting_id, 'events.xml')
+        return @disabled_recording_formats unless File.exist?(events_xml)
+
+        events = File.open(events_xml, 'r') { |io| Nokogiri::XML(io) }
+        @disabled_recording_formats = BigBlueButton::Events.disabled_recording_formats(events)
+      rescue StandardError => e
+        @logger.warn("Failed to read bbb-disable-recording-formats metadata: #{e.message}")
+        @disabled_recording_formats = []
       end
 
       def schedule_next_step

--- a/record-and-playback/core/lib/recordandplayback/workers/base_worker.rb
+++ b/record-and-playback/core/lib/recordandplayback/workers/base_worker.rb
@@ -119,22 +119,8 @@ module BigBlueButton
       end
 
       def disabled_recording_formats
-        return @disabled_recording_formats unless @disabled_recording_formats.nil?
-
-        @disabled_recording_formats = []
-        events_xml = File.join(@recording_dir, 'raw', @meeting_id, 'events.xml')
-        return @disabled_recording_formats unless File.exist?(events_xml)
-
-        metadata = BigBlueButton::Events.get_meeting_metadata(events_xml)
-        value = metadata['bbb-disable-recording-formats']
-        value = value.nil? ? '' : value.value.to_s
-        @disabled_recording_formats = value.delete('[]')
-                                           .split(',')
-                                           .map { |format| format.strip.downcase }
-                                           .reject(&:empty?)
-      rescue StandardError => e
-        @logger.warn("Failed to read bbb-disable-recording-formats metadata: #{e.message}")
-        @disabled_recording_formats = []
+        @disabled_recording_formats ||=
+          BigBlueButton.disabled_recording_formats(@recording_dir, @meeting_id)
       end
 
       def schedule_next_step

--- a/record-and-playback/core/scripts/rap-enqueue.rb
+++ b/record-and-playback/core/scripts/rap-enqueue.rb
@@ -33,6 +33,20 @@ def meeting_id_valid?(meeting_id)
   /\A[0-9a-f]+-[0-9]+\z/.match?(meeting_id)
 end
 
+# Formats the meeting opted out of through meta_bbb-disable-recording-formats.
+# Like the worker pipeline, unreadable metadata is logged and treated as
+# "nothing disabled"; bbb-record refuses on its own before removing any output.
+def disabled_recording_formats(recording_dir, meeting_id)
+  events_xml = File.join(recording_dir, 'raw', meeting_id, 'events.xml')
+  return [] unless File.exist?(events_xml)
+
+  events = File.open(events_xml, 'r') { |io| Nokogiri::XML(io) }
+  BigBlueButton::Events.disabled_recording_formats(events)
+rescue StandardError => e
+  warn "Failed to read bbb-disable-recording-formats metadata for #{meeting_id}: #{e.message}"
+  []
+end
+
 begin
   if ARGV.length < 2
     warn 'Usage: rap-enqueue.rb STEP[:FORMAT] MEETING_ID [MEETING_ID ...]'
@@ -75,8 +89,7 @@ begin
     # it schedules the next step itself, so a step enqueued directly here would
     # otherwise rebuild a format the meeting explicitly disabled.
     if !step_format.nil? &&
-       BigBlueButton.disabled_recording_formats(props['recording_dir'], meeting_id)
-                    .include?(step_format.downcase)
+       disabled_recording_formats(props['recording_dir'], meeting_id).include?(step_format.downcase)
       warn "Format #{step_format} is disabled for meeting #{meeting_id} " \
            'by meta_bbb-disable-recording-formats, not enqueuing'
       next

--- a/record-and-playback/core/scripts/rap-enqueue.rb
+++ b/record-and-playback/core/scripts/rap-enqueue.rb
@@ -71,6 +71,17 @@ begin
       next
     end
 
+    # Honour the per-meeting opt-out. The worker pipeline only checks this when
+    # it schedules the next step itself, so a step enqueued directly here would
+    # otherwise rebuild a format the meeting explicitly disabled.
+    if !step_format.nil? &&
+       BigBlueButton.disabled_recording_formats(props['recording_dir'], meeting_id)
+                    .include?(step_format.downcase)
+      warn "Format #{step_format} is disabled for meeting #{meeting_id} " \
+           'by meta_bbb-disable-recording-formats, not enqueuing'
+      next
+    end
+
     opts = common_opts.merge('meeting_id': meeting_id)
 
     warn "Enqueing #{step_name} worker with #{opts.inspect}"

--- a/record-and-playback/core/test/recordandplayback/generators/test_events.rb
+++ b/record-and-playback/core/test/recordandplayback/generators/test_events.rb
@@ -21,6 +21,26 @@ class TestEvents < Minitest::Test
     end
   end
 
+  def test_disabled_recording_formats_absent
+    assert_empty(BigBlueButton::Events.disabled_recording_formats(@events_meta_edt))
+  end
+
+  def test_disabled_recording_formats_parsed
+    events = Nokogiri::XML(<<~XML)
+      <recording>
+        <metadata bbb-disable-recording-formats="[ Video,PRESENTATION, ,podcast ]" />
+      </recording>
+    XML
+
+    assert_equal(%w[video presentation podcast], BigBlueButton::Events.disabled_recording_formats(events))
+  end
+
+  def test_disabled_recording_formats_empty_value
+    events = Nokogiri::XML('<recording><metadata bbb-disable-recording-formats="" /></recording>')
+
+    assert_empty(BigBlueButton::Events.disabled_recording_formats(events))
+  end
+
   def test_anonymous_user_map_legacy
     map = BigBlueButton::Events.anonymous_user_map(@events_legacy)
     assert_empty(map)


### PR DESCRIPTION
### What does this PR do?
Adds `--format <recording format name>` to `bbb-record`, usable with `--rebuild`,
`--rebuildall` and `--republish`, so a single playback format can be rebuilt or
republished instead of all of them.

Because the single-format path removes that format's published output *before*
enqueuing the new work, every way it can refuse is checked first, otherwise a
refusal leaves the recording deleted with nothing scheduled to replace it. The
guards, all applied before anything is removed:

- **Steps chain.** Refuses a format whose `process:<format>` entry has no next
  step. This is the state a server is in right after installing a
  `bbb-playback-<format>` package, which does not enable the format on its own
  (#12241), and it is the difference between a rebuild and a silent deletion:
  `process` runs, `schedule_next_step` finds no successor, publish never happens.
  The lookup merges `recording.yml` onto `bigbluebutton.yml` the same way
  `read_props` does, so an override that defines `steps` replaces the map.
- **Per-meeting opt-out.** `meta_bbb-disable-recording-formats` was only consulted
  by `schedule_next_step`, never by `rap-enqueue.rb`, so enqueuing a step directly
  rebuilt and republished a format the meeting had opted out of. The parsing now
  lives in `BigBlueButton::Events.disabled_recording_formats`, which takes an
  already parsed `events.xml` document; the worker and `rap-enqueue.rb` open the
  file themselves. `bbb-record` reads the same attribute with `xmlstarlet` (now a
  `bbb-config` dependency) and refuses when the file cannot be read, rather than
  taking a read failure for "not disabled".
- **Argument handling.** `--format` with no value used to fall through to the
  all-formats rebuild and delete every format's output. It now fails fast, must
  match `[a-z0-9_]+` and an installed process script, is validated once before
  any action runs, and is rejected on options that never honoured it. With
  `--delete` it was silently ignored and the whole recording was deleted.
- **Removal helpers.** The functions that run `rm` require a non-empty meeting id
  and format before touching anything, and the meeting id is local to
  `mark_for_rebuild` and `mark_for_republish` instead of overwriting the global.
- **Segments.** Removal is limited to the bare meeting id, which is the only
  thing `rap-enqueue.rb` can enqueue: its usage is `STEP[:FORMAT] MEETING_ID` and
  it never sets a break timestamp, so no job it creates rebuilds a segment.
  Segment (`<meeting id>-<break timestamp>`) artifacts are left in place rather
  than removed with nothing to restore them.

A batch run no longer aborts: one refused meeting is reported and the sweep
continues, while an explicit single meeting fails the command.

Documentation is updated: the option is added to the copied `bbb-record --help`
output so it stays in step with `usage()`, described next to `--rebuild` with
both refusal cases, and the format-installation section now points at
`--list-workflows` as the way to confirm a step took effect.

### Closes Issue(s)
Closes #25114
Supersedes #25375, whose commit this builds on.

### Motivation
Rebuilding every format to retest one of them is slow.

### How to test
Needs a server with more than one playback format installed. Install
`bbb-playback-video` and add `"process:video": "publish:video"` to the `steps`
map in `bigbluebutton.yml`.

Happy path:
1. `bbb-record --rebuild <id> --format video` on a recording with both formats
   published.
2. Only the video output is removed and re-processed; the presentation output and
   its done files are untouched.
3. The worker log shows `Process format succeeded … → Scheduling next step →
   Enqueueing publish worker … format_name video → Publish format succeeded`.

Refusals, each should print a reason, exit non-zero, and leave every format's
output in place:
- `--format` with no value, an unknown format, a format with a space, or one
  differing only by a regex metacharacter (`presenta.ion`).
- `--format video` **before** adding the `process:video` step entry, or with the
  entry present but null. Without the guard this deletes the video output and
  queues work that can never publish it.
- `--format video` on a meeting created with
  `meta_bbb-disable-recording-formats=[video]`. `--format presentation` on that
  same meeting must still proceed.
- `--format video` on a meeting whose `events.xml` is unreadable or malformed.
- `--format` passed to `--delete`.

Unit tests: `ruby -Ilib -Itest test/recordandplayback/generators/test_events.rb`
in `record-and-playback/core` covers the new `Events` helper.

Verified against real multi-format recordings on a 3.0 server.

### More
- Rebuilding segments would need a break timestamp on the enqueue side, which is
  a follow-up rather than part of this PR; #25741 is a prerequisite for it. Note
  that a full `--rebuild` of a segmented recording already collapses the segments
  today. This PR does not change that either way.
- The 4.0 port needs `yq` renamed to `yq-go` in `step_after` and the `xmlstarlet`
  dependency added to the noble `bbb-config` opts, matching #25398.

- [x] Added/updated documentation