### PR TITLE
ci: Test official plugins against BigBlueButton 4.0 in CI

### DIFF
--- a/.github/ci-tested-plugins.json
+++ b/.github/ci-tested-plugins.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "plugin-pick-random-user",
+    "repo": "bigbluebutton/bbb-plugin-pick-random-user",
+    "ref": "v0.1.2",
+    "servePath": "assets/plugins/pick-random-user-plugin",
+    "flakyTests": []
+  }
+]

--- a/.github/ci-tested-plugins.md
+++ b/.github/ci-tested-plugins.md
@@ -1,0 +1,57 @@
+# CI-tested official plugins
+
+`ci-tested-plugins.json` defines the list of official BigBlueButton plugins that are downloaded, built, and tested as part of the automated CI pipeline (`workflows/automated-tests.yml`).
+
+Each entry has the following fields:
+
+| Field | Description |
+|---|---|
+| `name` | Plugin identifier, used to name build artifacts and test directories |
+| `repo` | GitHub repository (`owner/repo`) to clone the plugin from |
+| `ref` | Git ref to download. Must be a **concrete** ref — a released tag (`v0.0.10`) or a commit SHA. It is passed straight to `https://github.com/<repo>/archive/<ref>.tar.gz`, so a ref that does not literally exist makes CI fail with a 404 |
+| `servePath` | Path under `/var/www/bigbluebutton-default/` where built assets are deployed. Note: nginx maps `/plugins/` URLs to `/var/www/bigbluebutton-default/assets/`, so use `assets/plugins/<name>` to serve at `/plugins/<name>/` |
+| `flakyTests` | Optional list of test names to skip in CI (merged with the plugin repo's own `flaky-tests.txt`) |
+
+To add a new official plugin to CI testing, add an entry to this file following the same structure. To mark a test as flaky without touching the plugin repo, add it to that plugin's `flakyTests` list using the format `Test Suite › Test Spec` (the separator is U+203A `›`, the same one Playwright uses in its test titles).
+
+Prefer pinning `ref` to a released tag rather than a branch: a branch moves under CI, so a green run on one commit says nothing about the next one, and a failure can no longer be reproduced from the config alone. Bump the tag deliberately when a new plugin release is out.
+
+### Example
+
+```json
+[
+  {
+    "name": "plugin-pick-random-user",
+    "repo": "bigbluebutton/bbb-plugin-pick-random-user",
+    "ref": "v0.0.10",
+    "servePath": "assets/plugins/pick-random-user-plugin",
+    "flakyTests": [
+      "My Suite › should do something when button is clicked",
+      "Another Suite › should handle edge case correctly"
+    ]
+  }
+]
+```
+
+## How the plugins are run
+
+Plugins are independent of one another — each suite injects only its own manifest URL and creates meetings with random IDs — so each one's full pipeline (download → `npm ci` → `build-bundle` → deploy → Playwright run) is treated as a single unit, and several units run concurrently in one job. Adding a plugin to the JSON is therefore the only thing needed; nothing else has to be touched.
+
+The behaviour is tuned through job-level env vars in `workflows/automated-tests.yml`:
+
+| Variable | Default | Effect |
+|---|---|---|
+| `PLUGIN_PARALLELISM` | `2` | How many plugins are processed at once. All plugins share one BBB instance and one runner, and each plugin's Playwright config uses a single worker under CI, so raising this trades wall-clock for contention. Set to `1` to process one plugin at a time |
+| `PLUGIN_TIMEOUT_MINUTES` | `15` | Wall-clock cap on one plugin's whole pipeline. A plugin that exceeds it is reported as a failure (exit 124) and the others carry on |
+| `PLUGIN_BUDGET_BASE_MINUTES` | `10` | Fixed slack in the step timeout, on top of the per-wave budget |
+
+The step timeout is **not** a fixed number: it is computed before the step runs, so adding plugins can't silently walk CI into a timeout. Plugins run `PLUGIN_PARALLELISM` at a time, so cost scales with the number of waves rather than the raw count:
+
+```
+waves   = ceil(plugin_count / PLUGIN_PARALLELISM)
+timeout = PLUGIN_BUDGET_BASE_MINUTES + waves * PLUGIN_TIMEOUT_MINUTES
+```
+
+Budgeting a full `PLUGIN_TIMEOUT_MINUTES` per wave guarantees the step can never be killed before every plugin has had its own cap — so a red build always points at a specific plugin instead of at the step timeout. With the defaults: 1 plugin → 25 min, 3 plugins → 40 min, 10 plugins → 85 min. These are ceilings, not expected runtimes; a healthy plugin pipeline takes a few minutes.
+
+Per-plugin output is buffered and replayed as a collapsible group at the end of the step, so concurrent runs don't interleave in the CI log.

--- a/.github/workflows/automated-tests.yml
+++ b/.github/workflows/automated-tests.yml
@@ -515,6 +515,19 @@ jobs:
       fail-fast: false
     env:
       SAMPLES_WITH_TESTS: "sample-action-button-dropdown-plugin sample-actions-bar-plugin sample-audio-settings-dropdown-plugin sample-camera-settings-dropdown-plugin sample-custom-subscription-hook sample-data-channel-plugin"
+      # --- Official plugin testing knobs (see .github/ci-tested-plugins.md) ---
+      # How many official plugins are downloaded, built and tested at once. They are
+      # independent of each other (each suite injects only its own manifest URL and
+      # creates meetings with random IDs), but they share a single BBB instance and a
+      # single runner, and each plugin's Playwright config runs one worker under CI -
+      # so keep this low. Set it to 1 to test one plugin at a time.
+      PLUGIN_PARALLELISM: 2
+      # Wall-clock cap for a single plugin's whole pipeline: download, npm ci, build,
+      # deploy and its Playwright run. Stops one hanging suite from eating the step.
+      PLUGIN_TIMEOUT_MINUTES: 15
+      # Fixed slack added on top of the computed per-wave budget, covering the step's
+      # own setup and the report handling around it.
+      PLUGIN_BUDGET_BASE_MINUTES: 10
     steps:
       - name: Checkout PR's source merged into its target branch
         if: github.event_name == 'pull_request'
@@ -658,6 +671,185 @@ jobs:
           else
             npm run test-chromium-ci
           fi
+      - name: Compute official plugin test budget
+        id: plugin-budget
+        run: |
+          # The step timeout has to grow with the plugin list, otherwise adding
+          # plugins silently walks CI into a timeout. Plugins run PLUGIN_PARALLELISM
+          # at a time, so the cost scales with the number of *waves*, not with the
+          # raw plugin count. Budgeting a full PLUGIN_TIMEOUT_MINUTES per wave means
+          # the step can never be killed before every plugin has had its own cap.
+          COUNT="$(jq 'length' .github/ci-tested-plugins.json)"
+          WAVES=$(( (COUNT + PLUGIN_PARALLELISM - 1) / PLUGIN_PARALLELISM ))
+          TIMEOUT=$(( PLUGIN_BUDGET_BASE_MINUTES + WAVES * PLUGIN_TIMEOUT_MINUTES ))
+          echo "$COUNT plugin(s), $PLUGIN_PARALLELISM at a time -> $WAVES wave(s) -> ${TIMEOUT}min step timeout"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "timeout=$TIMEOUT" >> "$GITHUB_OUTPUT"
+      - name: Test official plugins
+        # fromJSON turns the output string into the number timeout-minutes expects.
+        timeout-minutes: ${{ fromJSON(steps.plugin-budget.outputs.timeout) }}
+        env:
+          NODE_EXTRA_CA_CERTS: /usr/local/share/ca-certificates/bbb-dev/bbb-dev-ca.crt
+          ACTIONS_RUNNER_DEBUG: true
+          BBB_URL: https://bbb-ci.test/bigbluebutton/
+          BBB_SECRET: bbbci
+        run: |
+          PLUGINS_JSON="$GITHUB_WORKSPACE/.github/ci-tested-plugins.json"
+          LOG_DIR="$(mktemp -d)"
+          mkdir -p bigbluebutton-tests/official-plugins
+
+          plugin_field() {
+            jq -r --arg name "$1" --arg field "$2" \
+              '.[] | select(.name == $name) | .[$field] // ""' "$PLUGINS_JSON"
+          }
+
+          normalize_flaky() {
+            grep -Ev '^[[:space:]]*(#|$)' \
+              | sed 's/\r$//' \
+              | sed -E 's/[][(){}.^$*+?|\]/\\&/g' \
+              | sed 's/ › /.*/g'
+          }
+
+          # Download, build, deploy and test one plugin. Inherits `set -e`, so it
+          # stops at the first failing command and the caller records the status.
+          test_plugin() {
+            local NAME="$1"
+            local REPO REF SERVE_PATH FLAKY_PATTERN
+            REPO="$(plugin_field "$NAME" repo)"
+            REF="$(plugin_field "$NAME" ref)"
+            SERVE_PATH="$(plugin_field "$NAME" servePath)"
+
+            echo "Downloading $NAME from $REPO at ref $REF"
+            mkdir -p "bigbluebutton-tests/official-plugins/$NAME"
+            wget --no-verbose -O "/tmp/${NAME}.tar.gz" "https://github.com/${REPO}/archive/${REF}.tar.gz"
+            tar -xzf "/tmp/${NAME}.tar.gz" -C "bigbluebutton-tests/official-plugins/$NAME" --strip-components=1
+
+            cd "bigbluebutton-tests/official-plugins/$NAME"
+
+            echo "Building $NAME"
+            npm ci
+            npm run build-bundle
+            sudo mkdir -p "/var/www/bigbluebutton-default/${SERVE_PATH}"
+            sudo cp -r dist "/var/www/bigbluebutton-default/${SERVE_PATH}/"
+
+            # Every plugin writes to the same ~/.cache/ms-playwright, so the browser
+            # installs are serialised to avoid concurrent writes to one cache entry.
+            echo "Installing Playwright browsers for $NAME"
+            flock /tmp/playwright-install.lock npx playwright install chromium
+
+            FLAKY_PATTERN="$({
+              if [ -f "flaky-tests.txt" ]; then
+                normalize_flaky < flaky-tests.txt || true
+              fi
+              jq -r --arg name "$NAME" '.[] | select(.name == $name) | .flakyTests // [] | .[]' \
+                "$PLUGINS_JSON" \
+                | normalize_flaky
+            } | sort -u | paste -sd'|' -)"
+
+            echo "Running tests for $NAME"
+            if [ -n "$FLAKY_PATTERN" ]; then
+              npm run test-chromium-ci -- --grep-invert "$FLAKY_PATTERN"
+            else
+              npm run test-chromium-ci
+            fi
+          }
+
+          # `timeout` needs a command, so the helpers are exported and re-entered
+          # through a child bash below.
+          export -f test_plugin plugin_field normalize_flaky
+          export PLUGINS_JSON
+
+          # Fan out over the plugin list, at most $PLUGIN_PARALLELISM at a time. Each
+          # plugin's output is buffered to its own file and replayed as a collapsible
+          # group once everything finished, so concurrent runs don't interleave in the
+          # CI log.
+          while IFS= read -r NAME; do
+            while [ "$(jobs -rp | wc -l)" -ge "$PLUGIN_PARALLELISM" ]; do
+              # Frees up a slot. The reaped job's exit status is read back from its
+              # status file below, so discarding it here loses nothing.
+              wait -n || true
+            done
+            echo "Starting $NAME"
+            {
+              status=0
+              timeout -k 30s "${PLUGIN_TIMEOUT_MINUTES}m" \
+                bash -ec 'test_plugin "$1"' _ "$NAME" > "$LOG_DIR/$NAME.log" 2>&1 || status=$?
+              if [ "$status" -eq 124 ]; then
+                echo "Timed out after ${PLUGIN_TIMEOUT_MINUTES}m" >> "$LOG_DIR/$NAME.log"
+              fi
+              echo "$status" > "$LOG_DIR/$NAME.status"
+            } &
+          done < <(jq -r '.[].name' "$PLUGINS_JSON")
+          wait || true
+
+          overall_exit=0
+          while IFS= read -r NAME; do
+            status="$(cat "$LOG_DIR/$NAME.status" 2>/dev/null || echo 1)"
+            echo "::group::$NAME (exit $status)"
+            cat "$LOG_DIR/$NAME.log" 2>/dev/null || true
+            echo "::endgroup::"
+            if [ "$status" -ne 0 ]; then
+              echo "::error::Official plugin failed: $NAME (exit $status)"
+              overall_exit=1
+            fi
+          done < <(jq -r '.[].name' "$PLUGINS_JSON")
+          exit $overall_exit
+      - if: failure()
+        name: Collect official plugin blob reports
+        shell: bash
+        run: |
+          # publish-report merges every `blob-report-*` artifact with `playwright
+          # merge-reports`, which only reads report files at the top level of the
+          # folder it is given. Uploading a `**/blob-report` glob would produce a
+          # nested layout that gets silently dropped from the combined report, so the
+          # per-plugin blobs are flattened into a single directory here. Blob files
+          # are named `report-<n>.zip` in every plugin, hence the name prefix.
+          mkdir -p bigbluebutton-tests/official-plugins-blob-report
+          jq -r '.[].name' .github/ci-tested-plugins.json \
+          | while IFS= read -r NAME; do
+            BLOB_DIR="bigbluebutton-tests/official-plugins/$NAME/blob-report"
+            [ -d "$BLOB_DIR" ] || continue
+            for BLOB in "$BLOB_DIR"/*; do
+              [ -e "$BLOB" ] || continue
+              cp "$BLOB" "bigbluebutton-tests/official-plugins-blob-report/${NAME}-$(basename "$BLOB")"
+            done
+          done
+      - if: failure()
+        name: Upload official plugin blob reports
+        uses: actions/upload-artifact@v6
+        with:
+          name: blob-report-official-plugins
+          path: bigbluebutton-tests/official-plugins-blob-report
+          if-no-files-found: ignore
+      - if: failure()
+        name: Generate official plugin HTML reports from blob reports
+        shell: bash
+        run: |
+          jq -r '.[].name' .github/ci-tested-plugins.json \
+          | while IFS= read -r NAME; do
+            BLOB_DIR="bigbluebutton-tests/official-plugins/$NAME/blob-report"
+            if [ -d "$BLOB_DIR" ]; then
+              echo "Generating HTML report for $NAME"
+              (
+                cd "bigbluebutton-tests/official-plugins/$NAME"
+                npx playwright merge-reports --reporter html ./blob-report
+              )
+            fi
+          done
+      - if: failure()
+        name: Upload official plugin HTML reports
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-report_official-plugins
+          path: bigbluebutton-tests/official-plugins/**/playwright-report
+          if-no-files-found: ignore
+      - if: always()
+        name: Upload official plugin logs
+        uses: actions/upload-artifact@v6
+        with:
+          name: browser-logs-official-plugins
+          path: bigbluebutton-tests/official-plugins/**/logs
+          if-no-files-found: ignore
       - if: failure()
         name: Upload blob report to GitHub Actions Artifacts
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Overview

This ports the official plugin CI coverage from https://github.com/bigbluebutton/bigbluebutton/pull/25344 to the BigBlueButton 4.0 branch.

The implementation keeps the original workflow and documentation byte-identical, except for the tested plugin ref. BigBlueButton 4.0 uses `bbb-plugin-pick-random-user` `v0.1.2` instead of `v0.0.10`.

## Why the ref differs

The BigBlueButton 4.0 client currently provides HTML plugin SDK `0.1.26`.

- Plugin `v0.1.2` requires SDK `~0.1.9` and loaded successfully.
- Plugin `v0.0.10` requires SDK `~0.0.92` and was rejected by `bbb-apps-akka` because that requirement does not accept SDK `0.1.26`.

## Validation

Static validation:

- Parsed the complete workflow as YAML.
- Ran `bash -n` against all 14 shell blocks in the plugin test job.
- Confirmed the one-plugin budget calculation: one wave and a 25-minute step timeout.
- Confirmed the resulting files match the merged effect of the original PR, except for the declared plugin ref change.

Functional validation against a BigBlueButton 4.0 server built from `v4.0.x-develop`:

- Built and deployed `bbb-plugin-pick-random-user` `v0.1.2`.
- Confirmed the manifest changed from HTTP 404 to HTTP 200.
- Ran `npm run test-chromium-ci`: 14 passed and 2 skipped.
- Confirmed the plugin rows had an empty `loadFailureReason`.
- Published the `v0.0.10` manifest as a counter-proof and confirmed the expected SDK compatibility rejection from `bbb-apps-akka`.

A real GitHub Actions run was not executed in this private environment.

## How to test

1. Run the `install-and-run-plugin-tests` job on a BigBlueButton 4.0 GitHub Actions runner.
2. Confirm the `Compute official plugin test budget` step reports one plugin, one wave, and a 25-minute timeout.
3. Confirm `Test official plugins` downloads `bigbluebutton/bbb-plugin-pick-random-user` at `v0.1.2`.
4. Confirm the plugin builds, is deployed under `/plugins/pick-random-user-plugin/dist/`, and its Chromium test suite passes.
5. If the suite fails, confirm the official plugin blob reports, HTML reports, and browser logs are uploaded.
