### PR TITLE
fix(breakout): hide rejected presentations from the slide selection

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/sidebar-create-breakout/container.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/create-breakout-room/sidebar-create-breakout/container.tsx
@@ -52,6 +52,7 @@ const SidebarCreateBreakoutContainer: React.FC = () => {
   const { data: presentationData } = useDeduplicatedSubscription<
     PresentationsSubscriptionResponse>(PRESENTATIONS_SUBSCRIPTION);
   const presentations = presentationData?.pres_presentation || [];
+  // Unfiltered on purpose: `current` is only set after conversion completes, so a rejected upload is never current.
   const currentPresentation = presentations.find(
     (p: Presentation) => p.current,
   )?.presentationId || '';
@@ -86,7 +87,7 @@ const SidebarCreateBreakoutContainer: React.FC = () => {
   return (
     <SidebarCreateBreakout
       users={(usersData?.filter((u) => !u.bot) ?? []) as BreakoutUser[]}
-      presentations={presentations}
+      presentations={presentations.filter((p) => p && p.uploadCompleted)}
       currentPresentation={currentPresentation}
       isBreakoutRecordable={currentMeeting?.breakoutPolicies?.record ?? true}
       groups={meetingGroupData?.meeting_group ?? []}

--- a/bigbluebutton-tests/playwright/breakout/breakout.spec.ts
+++ b/bigbluebutton-tests/playwright/breakout/breakout.spec.ts
@@ -42,6 +42,25 @@ test.describe.parallel('Breakout', { tag: '@ci' }, () => {
       await create.dragDropUserInRoom();
     });
 
+    test('Rejected presentation does not enable the slide selection', async ({ browser, context, page }, testInfo) => {
+      linkIssue(25704);
+      const create = new Create(browser, context);
+      await create.initModPage(page, { testInfo });
+      await create.rejectedPresentationDoesNotEnableSlideSelection();
+    });
+
+    // Assumes default.pdf exists and maxFileSizeUpload is the 30 MB default; overriding either fails this confusingly.
+    test('Rejected presentation is not offered as a breakout room slide', async ({
+      browser,
+      context,
+      page,
+    }, testInfo) => {
+      linkIssue(25704);
+      const create = new Create(browser, context);
+      await create.initModPage(page, { testInfo });
+      await create.rejectedPresentationIsNotOfferedAsBreakoutSlide();
+    });
+
     test('Inherit lock settings checkbox is visible and unchecked by default', async ({ browser, context, page }, testInfo) => {
       const create = new Create(browser, context);
       await create.initPages(page, testInfo);

--- a/bigbluebutton-tests/playwright/breakout/create.ts
+++ b/bigbluebutton-tests/playwright/breakout/create.ts
@@ -2,6 +2,7 @@ import { expect, Page as PlaywrightPage } from '@playwright/test';
 
 import { ELEMENT_WAIT_EXTRA_LONG_TIME, ELEMENT_WAIT_LONGER_TIME, ELEMENT_WAIT_TIME } from '../core/constants';
 import { elements as e } from '../core/elements';
+import { uploadOversizedPresentation, uploadSinglePresentation } from '../presentation/util';
 import { MultiUsers } from '../user/multiusers';
 
 export class Create extends MultiUsers {
@@ -478,5 +479,47 @@ export class Create extends MultiUsers {
       ELEMENT_WAIT_LONGER_TIME,
     );
     await this.modPage.setHeightWidthViewPortSize(); // reset to default size
+  }
+
+  async rejectedPresentationDoesNotEnableSlideSelection() {
+    if (!this?.modPage) throw new Error('modPage not initialized');
+
+    await this.modPage.waitForSelector(e.whiteboard);
+    await this.modPage.closeAllToastNotifications();
+    await uploadOversizedPresentation(this.modPage, e.rejectedPresentationFileName);
+
+    await this.modPage.waitAndClick(e.breakoutRoomSidebarButton);
+    await this.modPage.hasElement(
+      e.createBreakoutRoomsButton,
+      'should display the breakout room creation panel',
+      ELEMENT_WAIT_LONGER_TIME,
+    );
+    // default.pdf is the only accepted presentation, so there is nothing to choose from
+    await this.modPage.wasRemoved(
+      e.changeSlideBreakoutRoom1,
+      'should not display the slide selection when the only other presentation was rejected on upload',
+    );
+  }
+
+  async rejectedPresentationIsNotOfferedAsBreakoutSlide() {
+    if (!this?.modPage) throw new Error('modPage not initialized');
+
+    await this.modPage.waitForSelector(e.whiteboard);
+    await this.modPage.closeAllToastNotifications();
+    await uploadSinglePresentation(this.modPage, e.uploadPresentationFileName);
+    await this.modPage.closeAllToastNotifications();
+    await uploadOversizedPresentation(this.modPage, e.rejectedPresentationFileName);
+
+    await this.modPage.waitAndClick(e.breakoutRoomSidebarButton);
+    await this.modPage.waitAndClick(e.changeSlideBreakoutRoom1, ELEMENT_WAIT_LONGER_TIME);
+    const listbox = this.modPage.page.locator('ul[role="listbox"]');
+    await expect(
+      listbox.locator('li[role="option"]'),
+      'should display 3 available options on presentation selection (current slide, default and the accepted presentation)',
+    ).toHaveCount(3);
+    await expect(
+      listbox.locator('li[role="option"]', { hasText: e.rejectedPresentationFileName }),
+      'should not offer the rejected presentation as a breakout room slide',
+    ).toHaveCount(0);
   }
 }

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -426,6 +426,9 @@ export const elements = {
   // Presentation
   currentSlideImg: '[id="whiteboard-element"] [class="tl-image"]',
   uploadPresentationFileName: 'uploadTest.png',
+  // Generated in memory by uploadOversizedPresentation - no fixture over the upload size
+  // limit is committed to the repo.
+  rejectedPresentationFileName: 'oversized.pdf',
   presentationPPTX: 'BBB.pptx',
   presentationTXT: 'helloWorld.txt',
   // sample.pdf pages are 595.27x841.89 pt (A4 portrait, ratio ~0.707), a source whose
@@ -486,6 +489,7 @@ export const elements = {
   presentationPlaceholderLabel: 'There is no currently active presentation',
   noPresentationLabel: 'There is no currently active presentation',
   presentationDownloadEnabledLabel: 'You can now download the presentation',
+  presentationTooLargeLabel: 'File is too large, exceeded the maximum of',
 
   // Settings
   settingsSidebarButton: 'div[data-test="settingsSidebarButton"]',

--- a/bigbluebutton-tests/playwright/presentation/util.ts
+++ b/bigbluebutton-tests/playwright/presentation/util.ts
@@ -143,6 +143,50 @@ export async function uploadSinglePresentation(
   await hasCurrentPresentationToastElement(testPage, { timeout: uploadTimeout });
 }
 
+// The browser sends the whole file and bbb-web refuses it on size (maxFileSizeUpload, 30 MB
+// by default) before the PDF is ever parsed, so the payload only has to be big enough, not a
+// valid document. Building it in memory keeps a file that large out of the repo.
+const OVERSIZED_PRESENTATION_BYTES = 31 * 1000 * 1000;
+
+function buildOversizedPdf(sizeInBytes: number): Buffer {
+  const header = Buffer.from(
+    '%PDF-1.4\n' +
+      '1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n' +
+      '2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n' +
+      '3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]>>endobj\n',
+  );
+  const trailer = Buffer.from('\ntrailer<</Root 1 0 R/Size 4>>\n%%EOF\n');
+  const padding = Buffer.alloc(sizeInBytes - header.length - trailer.length, 0x25); // '%' - a PDF comment
+  return Buffer.concat([header, padding, trailer]);
+}
+
+// Sibling of uploadSinglePresentation for the rejected path: that one asserts a successful
+// upload (new thumbnail and slide change), which never happens for a rejected file.
+export async function uploadOversizedPresentation(testPage: Page, fileName: string) {
+  await testPage.waitAndClick(e.mediaAreaButton);
+  await testPage.waitAndClick(e.managePresentations);
+  await testPage.hasElement(
+    e.presentationFileUpload,
+    'should display the presentation space for uploading a new file, when the manage presentations is opened',
+  );
+  await testPage.page.waitForTimeout(500); // wait a bit for the presentations to load
+
+  await testPage.page.setInputFiles(e.presentationFileUpload, {
+    name: fileName,
+    mimeType: 'application/pdf',
+    buffer: buildOversizedPdf(OVERSIZED_PRESENTATION_BYTES),
+  });
+
+  await testPage.hasText(
+    e.presentationUploadProgressToast,
+    e.presentationTooLargeLabel,
+    'should display the size rejection on the presentation upload toast',
+    UPLOAD_PDF_WAIT_TIME,
+  );
+  await testPage.press('Escape'); // close the media sharing menu
+  await testPage.waitForSelectorDetached(e.presentationFileUpload);
+}
+
 export async function uploadMultiplePresentations(
   testPage: Page,
   fileNames: string[],


### PR DESCRIPTION
### What does this PR do?

Hides presentations rejected at upload (too large, too many pages, wrong type, virus scan) from the per-room slide selector of the breakout room creation panel. One-line fix: the sidebar container now filters the `PRESENTATIONS_SUBSCRIPTION` result by `uploadCompleted`, the same predicate the presentation manager (`media-sharing/presentation/container.jsx:86`) and the shared notes dropdown (`notes-dropdown/component.tsx:216`) already use.

This fixes the three symptoms that come from that unfiltered array:

- the rejected file was listed as a selectable "default slide" for a breakout room (choosing it produced an empty deck, since `PresentationUrlDownloadService.extractPage` falls back to the blank PDF for a missing source)
- in a fresh meeting, a single rejected upload made the selector appear at all (the render gate is `presentations.length > 1`)
- the implicit default for a room (`presentations[0]`) could be the rejected file

Upload rejection handling (toast, error keys, DB row) is untouched: those rows are still stored and reported, only the breakout selector stops consuming them. In-flight (still converting) presentations are also hidden, consistent with the other two consumers.

### Closes Issue(s)

Closes #25704

### Motivation

The `pres_presentation` row is created when the client requests the upload token, before any byte is sent. On rejection the server only marks the row with `uploadErrorMsgKey` and `uploadCompleted = false` - no handler deletes it, by design (the upload toast subscribes to the same data to report the error). Of the four consumers of `PRESENTATIONS_SUBSCRIPTION`, three already filtered on `uploadCompleted`; the breakout sidebar (introduced by PR #20860 and carried into the 4.0 redesign in PR #24691) read the array raw. Issue #25704 reports the visible result: a rejected file offered as a breakout slide.

### How to test

1. Join a meeting as moderator (2.7+ / v4.0.x-develop build).
2. Upload a file above the 30 MB limit; confirm the rejection toast ("File is too large...").
3. Open the breakout room creation panel: with only `default.pdf` accepted, the per-room slide selector must not appear at all.
4. Variant: first upload a valid presentation, then a rejected one. Open the room 1 selector: exactly 3 options (current slide, `default.pdf`, the valid upload), none carrying the rejected file name.
5. Regression: with two accepted presentations, pick one for room 1 and create the rooms (covered by the pre-existing suite test "Breakout rooms can use different presentations").

Automated coverage: two new Playwright tests in the `Breakout` suite (`@ci`), both linked to this issue, driven by a new `uploadOversizedPresentation` helper (PDF built in memory past the size limit). Both were run red against the unmodified build, failing for the right assertions, and green after the fix.

Evidence (before/after GIF+MP4 and screenshots, recorded from-source on `v4.0.x-develop`): see the linked PR.

### More

- No documentation changes: no documented behavior was altered.
- No server-side validation added for `presId` in the breakout payload; the backend already degrades gracefully (blank PDF). Worth doing as a complement, never as a replacement for this fix.
- 3.0 (`v3.0.x-develop`) has the same unfiltered read in `create-breakout-room/component.tsx:717-719` and is not touched here; happy to open the backport if the team wants it.
- Side finding left alone: `getCaptureFilename` in the same component counts duplicate capture names; with the filter, a still-converting capture is not counted (narrow name-collision window).
- Local checks: TypeScript compiles clean (html5 + playwright), ESLint clean on touched files. The Playwright husky `prettier --check` hook already fails on 24 pre-existing files on a clean checkout of `v4.0.x-develop`; the count is identical with this change and touched files are formatted clean.
