### PR TITLE
Fix audio-only tile ordering in unified layout

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/queries.ts
@@ -114,10 +114,7 @@ export const AUDIO_ONLY_USERS_SUBSCRIPTION = gql`
         isModerator: { _in: $moderatorValues },
         lastFloorTime: { _neq: "0" },
       },
-      order_by: {
-        lastFloorTime: desc,
-        userId: asc,
-      },
+      order_by: [{ lastFloorTime: desc }, { userId: asc }],
     ) {
       meetingId
       name


### PR DESCRIPTION
## Why

Audio-only tiles in the unified layout could stay pinned to arbitrary users without cameras instead of following the users who most recently received the floor. A live probe matrix, including `graphql-ws` subscriptions, showed that Hasura silently drops fields from object-form multi-field `order_by` clauses.

## What changed

The audio-only users subscription now passes the ordering fields as a list, with `lastFloorTime` descending and `userId` ascending. This matches the existing `USER_LIST_SUBSCRIPTION` convention and preserves a deterministic tie-breaker.

Closes #25703

## Validation

- HTML5 ESLint passed for the changed query file.
- HTML5 TypeScript compilation passed.
- The live before/after recording confirms that the audio-only tiles follow the newest floor grants.

## Evidence

- [Before: tiles remain on arbitrary camera-less users](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-09-10/34128753-3b6e-45df-9f51-8d7c0f90f2f2/before.mp4)
- [After: newest floor holder takes the tile](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-09-10/cee8e75f-63f3-4356-969e-45d04e0627a2/after.mp4)

Animated preview below. Click the GIF to open the higher-quality MP4:

[![After: newest floor holder takes the tile](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-09-10/04ce16c5-f925-4cf2-94c3-913eeb5fcdca/after.gif)](https://claudio.sfo3.digitaloceanspaces.com/work-evidences/2026-09-10/cee8e75f-63f3-4356-969e-45d04e0627a2/after.mp4)
