### PR TITLE
fix(audio): resolve a WASM-processed track to its real input device

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/service.js
@@ -462,11 +462,9 @@ const doGUM = async (
 
     const wasmProcessorStream = await createWasmProcessorStream(stream);
 
-    // Register the per-stream mapping from synthetic WebAudio-* device ID
-    // to the real device ID for later resolution
-    const syntheticDeviceId = wasmProcessorStream.getAudioTracks()[0]
-      ?.getSettings()?.deviceId;
-    MediaStreamUtils.registerWasmDeviceId(syntheticDeviceId, realDeviceId);
+    // Register the per-stream mapping from the processed tracks to the real
+    // device ID for later resolution
+    MediaStreamUtils.registerWasmDeviceId(wasmProcessorStream, realDeviceId);
 
     // Promote this processor as the primary for runtime control
     // (setWasmProcessorEnabled/Parameter/Destruction). E.g.: preview calls (audio-settings

--- a/bigbluebutton-html5/imports/utils/media-stream-utils.js
+++ b/bigbluebutton-html5/imports/utils/media-stream-utils.js
@@ -48,20 +48,32 @@ const getDeviceIdFromTrack = (track) => {
   return null;
 };
 
-// Maps synthetic WebAudio-* device IDs to real device IDs.
+// Maps WASM-processed tracks back to the real device they were captured from.
 // WASM-processed streams (from AudioContext.createMediaStreamDestination) have
-// a unique synthetic device ID per AudioContext. These IDs change on stream
-// cloning as well, making things even more impractical.
-// doGUM is charge of registering the mappings after WASM processing
+// no real device behind them. Chromium invents a synthetic WebAudio-* device ID
+// per AudioContext; Firefox reports an empty getSettings() and so has no
+// synthetic ID at all. Track IDs are the only key every browser exposes, so keep
+// both: the synthetic ID survives cloning and the track ID does not, so a cloned
+// processed stream resolves only where the browser supplies the synthetic one.
+// doGUM is in charge of registering the mappings after WASM processing
 const wasmDeviceIdMap = new Map();
 
-const registerWasmDeviceId = (syntheticDeviceId, realDeviceId) => {
-  if (syntheticDeviceId && realDeviceId) {
-    wasmDeviceIdMap.set(syntheticDeviceId, realDeviceId);
-  }
+const registerWasmDeviceId = (processedStream, realDeviceId) => {
+  if (!processedStream || !realDeviceId) return;
+
+  getAudioTracks(processedStream).forEach((track) => {
+    const syntheticDeviceId = getDeviceIdFromTrack(track);
+
+    if (syntheticDeviceId) wasmDeviceIdMap.set(syntheticDeviceId, realDeviceId);
+    if (track.id) wasmDeviceIdMap.set(track.id, realDeviceId);
+  });
 };
 
-const resolveDeviceId = (deviceId) => wasmDeviceIdMap.get(deviceId) ?? deviceId;
+const resolveTrackDeviceId = (track) => {
+  const deviceId = getDeviceIdFromTrack(track);
+
+  return wasmDeviceIdMap.get(deviceId) ?? wasmDeviceIdMap.get(track?.id) ?? deviceId;
+};
 
 const extractDeviceIdFromStream = (stream, kind) => {
   let tracks = [];
@@ -70,7 +82,7 @@ const extractDeviceIdFromStream = (stream, kind) => {
     case 'audio':
       tracks = getAudioTracks(stream);
       if (tracks.length === 0) return 'listen-only';
-      return resolveDeviceId(getDeviceIdFromTrack(tracks[0]));
+      return resolveTrackDeviceId(tracks[0]);
     case 'video':
       tracks = getVideoTracks(stream);
       return getDeviceIdFromTrack(tracks[0]);


### PR DESCRIPTION
### What does this PR do?

#### [fix(audio): resolve a WASM-processed track to its real input device](https://github.com/bigbluebutton/bigbluebutton/commit/470f205f7b647add2819082020f449d4186aeac3) 
  - The registry mapping a WASM-processed track back to the device it was
captured from is keyed on the synthetic WebAudio-* device ID Chromium
invents for MediaStreamAudioDestinationNode tracks. Firefox reports an
empty getSettings() for those, so nothing is registered and the processed
stream resolves to no device at all. Unmuting then matches none of the
local publications: inside the unpublish-after-mute window the track is
still published, so the republish fallback is skipped too and the unmute
is a no-op - and it cancels the pending unpublish, so the microphone
stays muted until audio is rejoined.
  - Key the registry on the processed track IDs as well, which every browser
exposes, and resolve a track through either key. The synthetic ID stays
registered where the browser provides one, so nothing changes for
Chromium.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/25769

### How to test

  - Enable audioWasmProcessing + BBBA in settings.yml
  - Enter a meeting with Firefox (F1) and a second session with any browser (A2)
  - F1: Unmute
  - F1: speak, verify heard by A2
  - F1: Switch filter to Advanced (BBBA)
  - F1: Mute, than within 5 seconds, unmute
  - F1: speak, verify heard by A2 again
