### PR TITLE
fix(livekit): leave the camera framerate unset when no profile sets it

### DIFF
--- a/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/service.ts
+++ b/bigbluebutton-html5/imports/ui/components/video-provider/livekit-camera-bridge/service.ts
@@ -5,6 +5,7 @@ import VideoService from '/imports/ui/components/video-provider/service';
 import {
   assemblePresetFromConfig,
   deduplicatePresets,
+  toPublishEncoding,
   type PresetDefaults,
 } from '/imports/ui/services/livekit/presets';
 
@@ -242,7 +243,8 @@ export const getCameraPublishOptions = (
     : getProfileBasedPresets(stream);
 
   const layers = presets.length > 1 ? presets.slice(0, -1) : [];
-  const topEncoding = presets[presets.length - 1]?.encoding;
+  const topPreset = presets[presets.length - 1];
+  const topEncoding = topPreset && toPublishEncoding(topPreset);
 
   logger.debug({
     logCode: 'livekit_camera_presets',

--- a/bigbluebutton-html5/imports/ui/services/livekit/presets.ts
+++ b/bigbluebutton-html5/imports/ui/services/livekit/presets.ts
@@ -1,4 +1,4 @@
-import { VideoPreset } from 'livekit-client';
+import { type VideoEncoding, VideoPreset } from 'livekit-client';
 import logger from '/imports/startup/client/logger';
 import { LiveKitPresetConfig } from '/imports/ui/Types/meetingClientSettings';
 
@@ -35,6 +35,17 @@ export const assemblePresetFromConfig = (
   }
 
   return new VideoPreset(width, height, maxBitrate, maxFramerate, priority);
+};
+
+export const toPublishEncoding = (preset: VideoPreset): VideoEncoding => {
+  const { maxFramerate, ...encoding } = preset.encoding;
+
+  // VideoPreset always produces the maxFramerate attribute on its encoding,
+  // so a preset built without a framerate carries the key with an undefined value.
+  // This is usually fine, but on scenarios where a single encoding is produced (ie
+  // low quality), this is forwarded verbatim to the transceiver call. Long story
+  // short: undefined becomes NaN which makes Firefox throw. Filter it out here to avoid that.
+  return maxFramerate == null ? encoding : { ...encoding, maxFramerate };
 };
 
 // Removes presets that are identical across all three encoding dimensions:

--- a/bigbluebutton-tests/playwright/webcam/webcam.ts
+++ b/bigbluebutton-tests/playwright/webcam/webcam.ts
@@ -114,6 +114,10 @@ export class Webcam extends Page {
       await this.waitForSelector(e.leaveVideo, VIDEO_LOADING_WAIT_TIME);
     };
 
+    // "low" is the lowest visible profile, so it publishes a single encoding
+    // instead of simulcast layers, and that encoding reaches the browser
+    // untouched - in #25587 it carried an undefined framerate, which Firefox
+    // refuses outright. Keep this step on the lowest quality.
     await joinWebcamSettingQuality('low');
     await this.waitAndClick(e.connectionStatusBtn);
     const lowValue = await checkVideoUploadData(this, 0);


### PR DESCRIPTION
### What does this PR do?

#### [fix(livekit): leave the camera framerate unset when no profile sets it](https://github.com/bigbluebutton/bigbluebutton/commit/5a5244a2ecf651ec9d1a7b625d4bdfd822ea306b) 
  - A camera profile without a frameRate constraint produces a preset
whose encoding carries maxFramerate with an undefined value.
Simulcast layers are rebuilt by livekit-client and lose it, but a single
encoding (e.g. Low profile) is forwarded verbatim to addTransceiver.
Long story short: undefined parses to NaN, Firefox throws and camera
sharing fails.
  - Omit the maxFramerate key when it is undefined while producing encoding
presets. Same end goal (leave it to the browser), but no FF breakage.

### Closes Issue(s)

Closes https://github.com/bigbluebutton/bigbluebutton/issues/25587

### How to test

From #25587:
> Select a camera quality whose profile has no frameRate constraint (e.g. Low) → publish fails with the RangeError. Selecting a profile that does carry constraints.frameRate (e.g. High) publishes fine — same p=1, l=0, so it's the framerate, not layer count/simulcast.