### PR TITLE
fix(livekit): do not re-mute a track a client just unmuted

### DIFF
--- a/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
+++ b/bigbluebutton-html5/imports/api/audio/client/bridge/livekit.ts
@@ -662,6 +662,23 @@ export default class LiveKitAudioBridge extends BaseAudioBridge {
       },
     }, `LiveKit: local audio track unmuted - ${trackSid}`);
 
+    // If we have a pending unmute request coming from us (the client) and we
+    // reached here first, it means the server already unmuted the track.
+    // Consume it to mark as done and skip reinforcing (unnecessary).
+    if (consumeMuteCommand(false)) {
+      logger.debug({
+        logCode: 'livekit_audio_mute_reinforce_skipped',
+        extraInfo: {
+          bridge: this.bridgeName,
+          role: this.role,
+          trackSid,
+          shouldBeMuted: this.shouldBeMuted,
+        },
+      }, `LiveKit: skipping mute reinforcement, unmute in flight - ${trackSid}`);
+
+      return;
+    }
+
     // The server is not notified of a track-level unmute, so if BBB's state is
     // muted we must re-mute here to reconcile states.
     this.reinforceMuteState('local_track_unmuted');

--- a/bigbluebutton-tests/playwright/audio/muteReinforcement.spec.ts
+++ b/bigbluebutton-tests/playwright/audio/muteReinforcement.spec.ts
@@ -14,10 +14,41 @@ interface TestMicPublication {
   isMuted: boolean;
   unmute: () => Promise<void>;
 }
+type TestParticipant = {
+  audioTrackPublications: Map<string, TestMicPublication>;
+  on: (event: string, handler: (publication: TestMicPublication) => void) => void;
+};
 type TestWindow = Window & {
   BBB_EXPOSE_LIVEKIT_ROOM?: boolean;
-  liveKitRoom?: { localParticipant: { audioTrackPublications: Map<string, TestMicPublication> } };
+  liveKitRoom?: { localParticipant: TestParticipant };
+  BBB_MIC_MUTE_EVENTS?: boolean[];
 };
+
+// Records the local mic track's mute state transitions as the LK SDK reports them.
+const startMicMuteProbe = (page: PlaywrightPage): Promise<void> =>
+  page.evaluate(() => {
+    const w = window as TestWindow;
+    const room = w.liveKitRoom;
+
+    if (!room) throw new Error('window.liveKitRoom is not exposed - the test must opt in before load');
+
+    if (w.BBB_MIC_MUTE_EVENTS) {
+      w.BBB_MIC_MUTE_EVENTS.length = 0;
+      return;
+    }
+
+    w.BBB_MIC_MUTE_EVENTS = [];
+
+    const record = (muted: boolean) => (publication: TestMicPublication) => {
+      if (publication.source === 'microphone') w.BBB_MIC_MUTE_EVENTS?.push(muted);
+    };
+
+    room.localParticipant.on('trackMuted', record(true));
+    room.localParticipant.on('trackUnmuted', record(false));
+  });
+
+const readMicMuteProbe = (page: PlaywrightPage): Promise<boolean[]> =>
+  page.evaluate(() => (window as TestWindow).BBB_MIC_MUTE_EVENTS ?? []);
 
 interface MicMuteState {
   hasRoom: boolean;
@@ -56,6 +87,21 @@ const snapshotThenUnmuteOutOfBand = (
     await Promise.all(pubs.map((pub) => pub.unmute()));
     return snapshot;
   });
+
+// Stable means: mic ends published and unmuted, and nothing muted it once it was unmuted.
+const expectStableUnmutedMic = async (page: PlaywrightPage, message: string): Promise<void> => {
+  await expect(async () => {
+    const mic = await readLocalMicMuteState(page);
+    expect(mic.count, 'the mic track should be published').toBeGreaterThan(0);
+    expect(mic.allMuted, 'the mic track should end up unmuted').toBeFalsy();
+  }).toPass({ timeout: ELEMENT_WAIT_LONGER_TIME });
+
+  const events = await readMicMuteProbe(page);
+  const firstUnmute = events.indexOf(false);
+
+  expect(firstUnmute, `the mic track should have been unmuted (events: ${events.join(',')})`).toBeGreaterThanOrEqual(0);
+  expect(events.slice(firstUnmute), `${message} (events: ${events.join(',')})`).not.toContain(true);
+};
 
 test.describe('Audio mute reinforcement', { tag: ['@ci', '@media'] }, () => {
   let audio: Audio;
@@ -104,5 +150,35 @@ test.describe('Audio mute reinforcement', { tag: ['@ci', '@media'] }, () => {
       const after = await readLocalMicMuteState(modPage.page);
       expect(after.allMuted, 'the LiveKit mic track must be re-muted to match BBB mute state').toBeTruthy();
     }).toPass({ timeout: ELEMENT_WAIT_LONGER_TIME });
+  });
+
+  // A BBB-initiated unmute reaches the client twice: via the LiveKit SDK and
+  // via GraphQL. The bridge must not read that first half (LK) as a desync that
+  // requires reinforcement (ie.: it  should not mute the track)
+  test('does not reinforce the muted state when BBB unmutes a published track', async () => {
+    test.skip(!isLiveKit, 'mute reinforcement is specific to the LiveKit audio bridge');
+    const { modPage } = audio;
+    if (!modPage) throw new Error('modPage not initialized');
+
+    await modPage.waitAndClick(e.joinAudio);
+    await connectMicrophone(modPage);
+    await modPage.hasElement(e.unmuteMicButton, 'should join audio muted');
+    await modPage.waitAndClick(e.unmuteMicButton);
+    await modPage.hasElement(e.isTalking, 'should be unmuted/talking after clicking unmute');
+    await audio.muteButtonCooldown();
+    await modPage.waitAndClick(e.muteMicButton);
+    await modPage.hasElement(e.unmuteMicButton, 'BBB should show the user as muted');
+
+    const before = await readLocalMicMuteState(modPage.page);
+    expect(before.hasRoom, 'liveKitRoom should be exposed for testing').toBeTruthy();
+    expect(before.count, 'a mic track should still be published while muted').toBeGreaterThan(0);
+    expect(before.allMuted, 'the mic track should be muted before the unmute').toBeTruthy();
+
+    await startMicMuteProbe(modPage.page);
+    await audio.muteButtonCooldown();
+    await modPage.waitAndClick(e.unmuteMicButton);
+    await modPage.hasElement(e.isTalking, 'should be unmuted/talking after clicking unmute');
+
+    await expectStableUnmutedMic(modPage.page, 'a user-driven unmute must not re-mute the track');
   });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes an issue where mute reinforcement was triggered when unmuting tracks
that are still published in LiveKit. Nothing is visible for the end user
as the system self-corrects, but a spurious reinforcement log is generated
and we're risking a race condition here (of the I'm unmuted-but-muted sort).
Add test coverage for this.

#### [fix(livekit): do not re-mute a track a client just unmuted](https://github.com/bigbluebutton/bigbluebutton/commit/da4e2068f1dc6cb8fc8c860c770101cd8221dfad) 
  - A system to stamp mute requests as client-initiated was recently
  introduced to improve some reconnection scenarios. Use it - consume the
  intent when the TrackUnmute event is fired by the LK SDK. If it was in
  fact client-initiated (consumed=true), then skip the reinforcement
  routine.

### Closes Issue(s)

None

### How to test

- Open a meeting, join with U1
- U1: unmute, then mute. Within 5 seconds, unmute again
- Check console/client logs: no mute reinforcement log should be present