### PR TITLE
fix(html5): disable breakout listen-in for a room the user is joined in

### DIFF
--- a/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/TransferUserToMeetingRequestHdlr.scala
+++ b/akka-bbb-apps/src/main/scala/org/bigbluebutton/core/apps/breakout/TransferUserToMeetingRequestHdlr.scala
@@ -111,6 +111,13 @@ trait TransferUserToMeetingRequestHdlr extends HandlerHelpers with RightsManagem
       return
     }
 
+    val joinedInTarget = breakoutFound.exists(room => room.users.exists(_.extId == s"$userId-${room.sequence}"))
+
+    if (joinedInTarget) {
+      log.warning("livekitTransferIntoMeeting: user {} is joined in breakout {}, rejecting listen-in", userId, toMeetingId)
+      return
+    }
+
     // Auto switch: clear any previous breakout-listen membership first.
     val existingMemberships = LiveKitMemberships.findByUserAndPurpose(liveMeeting.liveKitMemberships, userId, "breakout-listen")
 

--- a/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/running-room/component.tsx
+++ b/bigbluebutton-html5/imports/ui/components/breakout-room/breakout-room/running-room/component.tsx
@@ -94,6 +94,10 @@ const intlMessages = defineMessages({
     id: 'app.createBreakoutRoom.stopListeningToRoom',
     description: 'Stop listening to breakout room audio',
   },
+  listenAlreadyInRoom: {
+    id: 'app.createBreakoutRoom.listenAlreadyInRoom',
+    description: 'Listen option label while the user is joined in that breakout room',
+  },
   sendMessage: {
     id: 'app.chat.submitLabel',
     description: 'Send message button label',
@@ -230,6 +234,8 @@ const RunningBreakoutRoom: React.FC<RunningBreakoutRoomProps> = ({
   ]);
 
   const handleListenToRoom = useCallback((breakout: BreakoutRoomType) => {
+    if (breakout.isUserCurrentlyInRoom) return;
+
     if (listeningToRoomId === breakout.breakoutRoomMeetingId) {
       breakoutRoomTransfer({
         variables: {
@@ -486,9 +492,14 @@ const RunningBreakoutRoom: React.FC<RunningBreakoutRoomProps> = ({
                         },
                         {
                           key: `listen-${breakout.breakoutRoomMeetingId}`,
-                          label: isListening
-                            ? intl.formatMessage(intlMessages.stopListeningToRoom)
-                            : intl.formatMessage(intlMessages.listenToRoom),
+                          // A live full join in this room (another tab) would play the
+                          // listen-in mic back to the user through that session.
+                          label: breakout.isUserCurrentlyInRoom
+                            ? intl.formatMessage(intlMessages.listenAlreadyInRoom)
+                            : intl.formatMessage(
+                              isListening ? intlMessages.stopListeningToRoom : intlMessages.listenToRoom,
+                            ),
+                          disabled: breakout.isUserCurrentlyInRoom,
                           dataTest: `listenToBreakoutRoomButton${breakout.sequence}`,
                           onClick: () => handleListenToRoom(breakout),
                         },

--- a/bigbluebutton-html5/public/locales/en.json
+++ b/bigbluebutton-html5/public/locales/en.json
@@ -1628,6 +1628,7 @@
     "app.createBreakoutRoom.returnToMainSession": "Return to Main Session",
     "app.createBreakoutRoom.listenToRoom": "Listen to room",
     "app.createBreakoutRoom.stopListeningToRoom": "Stop listening",
+    "app.createBreakoutRoom.listenAlreadyInRoom": "Can't listen: already in room",
     "app.updateBreakoutRoom.modalDesc": "To update or invite a user, simply drag them into the desired room.",
     "app.updateBreakoutRoom.cancelLabel": "Cancel",
     "app.updateBreakoutRoom.title": "Update Breakout Rooms",

--- a/bigbluebutton-tests/playwright/breakout/join.ts
+++ b/bigbluebutton-tests/playwright/breakout/join.ts
@@ -181,6 +181,17 @@ export class Join extends Create {
     await this.modPage.waitAndClick(e.askJoinRoom2);
     await this.modPage.waitAndClick(e.roomOptions2);
     await this.modPage.waitForSelector(e.alreadyConnected, ELEMENT_WAIT_LONGER_TIME);
+    await this.modPage.hasElementDisabled(
+      e.listenToBreakoutRoomButton2,
+      'should disable listening to a breakout room the moderator is already joined in',
+    );
+    await this.modPage.press('Escape');
+    await this.modPage.waitAndClick(e.roomOptions1);
+    await this.modPage.hasElementEnabled(
+      e.listenToBreakoutRoomButton1,
+      'should keep listening enabled for a breakout room the moderator is not joined in',
+    );
+    await this.modPage.press('Escape');
 
     const breakoutModPage = await this.modPage.getLastTargetPage(this.context);
     await breakoutModPage.page.bringToFront();

--- a/bigbluebutton-tests/playwright/core/elements.ts
+++ b/bigbluebutton-tests/playwright/core/elements.ts
@@ -158,6 +158,8 @@ export const elements = {
   callModeratorButton: 'button[data-test="callModeratorButton"]',
   returnToMainSessionButton: 'button[data-test="returnToMainSessionButton"]',
   listenToBreakoutRoomButton: 'li[data-test^="listenToBreakoutRoomButton"]',
+  listenToBreakoutRoomButton1: 'li[data-test="listenToBreakoutRoomButton1"]',
+  listenToBreakoutRoomButton2: 'li[data-test="listenToBreakoutRoomButton2"]',
   breakoutTransferReturnButton: 'button[data-test="breakoutTransferReturnButton"]',
   breakoutListenToast: 'div[data-test="breakoutListenToast"]',
 

--- a/docs/docs/testing/release-testing.md
+++ b/docs/docs/testing/release-testing.md
@@ -568,6 +568,9 @@ Requires the LiveKit audio bridge (the default). A viewer must be in a breakout 
 3. Click "Return to main room".
 
    - the notification should close, main-room audio should resume, and unmuting should make you audible in the main room again
+4. Pick "Join room" for a running room (it opens in a new tab), then reopen that room's options menu in the main room.
+
+   - the listen option should be disabled and read "Can't listen: already in room"; other rooms' listen options stay enabled
 
 ## Audio
 


### PR DESCRIPTION
### What does this PR do?
Disables the "Listen to room" option in a breakout room's options menu while the
current user holds a live join in that room from another tab. The item renders
disabled with its own "Can't listen: already in room" label next to the "Join
room" item's "Already in room", and a stale click is ignored. Other rooms stay
listenable.

The server rejects the same transfer as a backstop for a client whose view lags
the join, and the Playwright moderator-join flow asserts both the disabled item
and that another room's listen option stays enabled.

**In detail**
- `fix(html5): disable breakout listen-in for a room the user is joined in`
- `test(playwright): assert listen-in is disabled for a joined breakout`
- `fix(core): reject a LiveKit listen-in into a breakout the user is joined in`
  - The parent actor already lists each breakout's users by external id
    (`userId-sequence`); a transfer into a room that lists the user's own session
    is rejected before any write.

### Closes Issue(s)
None. Follow-up to #25638.

### Motivation
With a full join in the breakout and a listen-in into the same room from the
parent tab, the parent tab's microphone is published into a room the other tab
is subscribed to: the user hears their own voice through that tab, and the
breakout's audio plays from two renderers, one of which the main room cannot
control. The reverse order (listen first, then join) already returns the
transfer before opening the room; this closes the other entry point. Reported
from a production session where a moderator did exactly this.

### How to test
Any audio bridge for the client gate; LiveKit for the server backstop.
Moderator + one attendee, breakouts with two rooms, the attendee assigned to
room 1.
1. Moderator: breakouts panel → room 2 options → "Join room" (opens in a new tab).
2. Back in the main tab, reopen room 2's options: "Listen to room" is disabled
   and reads "Can't listen: already in room"; room 1's "Listen to room" is still
   enabled and works.
3. Close the breakout tab: after the leave grace period room 2's item is
   enabled again.
